### PR TITLE
[MAINTENANCE] Add a default interpolator argument to FileSource

### DIFF
--- a/ingen/data_source/file_source.py
+++ b/ingen/data_source/file_source.py
@@ -6,6 +6,7 @@ from datetime import date
 
 from ingen.data_source.source import DataSource
 from ingen.reader.file_reader import ReaderFactory
+from ingen.utils.interpolators.Interpolator import Interpolator
 from ingen.utils.path_parser import PathParser
 from ingen.utils.timer import log_time
 
@@ -17,7 +18,7 @@ class FileSource(DataSource):
     This class represents a File source
     """
 
-    def __init__(self, source, params_map):
+    def __init__(self, source, params_map, interpolator=Interpolator()):
         """
         Loads a file
 
@@ -26,6 +27,7 @@ class FileSource(DataSource):
 
         """
         super().__init__(source.get('id'))
+        self.interpolator = interpolator
         if params_map.get('infile') and source['use_infile']:
             source['file_path'] = params_map['infile']
             self._src = source
@@ -61,7 +63,7 @@ class FileSource(DataSource):
         else:
             run_date = params_map.get('run_date', date.today())
 
-        path_parser = PathParser(run_date)
+        path_parser = PathParser(run_date, interpolator=self.interpolator)
         if 'file_path' in source:
             source['file_path'] = path_parser.parse(source['file_path'])
         return source

--- a/test/data_source/test_file_source.py
+++ b/test/data_source/test_file_source.py
@@ -26,7 +26,7 @@ class TestFileSource(unittest.TestCase):
         self.params_map = {'query_params': {'table_name': 'positions'}, 'infile': {}}
         self.source = FileSource(self._src, self.params_map)
 
-    @patch('src.data_source.file_source.ReaderFactory')
+    @patch('ingen.data_source.file_source.ReaderFactory')
     def test_source_fetch(self, mock_reader_factory):
         fileReader = Mock()
         fileReader.read.return_value = pd.DataFrame()


### PR DESCRIPTION
## Description
Adding interpolator to '__init__' method of FileSource so that a custom interpolator can be passed to it. It defaults to the existing Interpolator we have. This will allow any one extending ingen library to add their own custom interpolator functions that can be used in parsing file paths.

## Changes Made
Added a default argument to FileSource and used it to create PathParser.

## Definition of Done

Before submitting this pull request, please ensure that the following criteria have been met:

- [x] All automated tests have passed successfully.
- [x] All manual tests have passed successfully.
- [ ] Code has been reviewed by at least one other team member.
- [x] Code has been properly documented and commented as needed.
- [x] All new and existing code adheres to our project's coding standards.
- [x] All dependencies have been added or removed from the project's README or other documentation as needed.
- [x] Any relevant documentation or help files have been updated to reflect the changes made in this pull request.
- [n/a] Any necessary database migrations have been run.
