### PR TITLE
[MAINTENANCE] upgrade pycryptodome to 3.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ holidays==0.27.*
 hvac==0.11.*
 numpy==1.26.*
 pandas==1.3.*
-pycryptodome==3.11.*
+pycryptodome==3.20.0
 PyMySQL==1.1.*
 PyYAML==6.0.*
 setuptools==68.0.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ pandas==1.3.*
 pycryptodome==3.20.0
 PyMySQL==1.1.*
 PyYAML==6.0.*
-setuptools==68.0.*
 xmltodict==0.12.*


### PR DESCRIPTION
## Description

Upgraded pycryptodome to 3.20.0 and removed setuptools from requirements.txt

