### PR TITLE
[FEATURE] Multiple Output file generation in an Interface

### DIFF
--- a/docs/config_reference.md
+++ b/docs/config_reference.md
@@ -877,7 +877,8 @@ Expects all column values to be present in all columns of sources provided.
 	    args: [[COL_2, cusip], [COL_3,cusip]]
 'args' takes list of all sources along with the column name, in which we need to check whether all values of current column are present.
 
-Output
+**Output**
+
 The output object is used to declare how the output data should be persisted. The following code snippet shows an example of storing data into an excel file:
 output:
 	type: excel
@@ -886,12 +887,24 @@ output:
 The 'type' field can take two values:
 •	excel - for Excel sheets
 •	file - for any delimited files like csv, psv, etc
+
 The following example declares a CSV output
+```
 output:
-	type: file
-	props:
-		delimiter: ','
-		path: 'path/to/write/file.xls'
+  type: file
+  props:
+    delimiter: ','
+    path: 'path/to/write/file.xls'
+```
+
+For use cases where we need to generate the same output file in different locations, such as saving copies of the same data in multiple directories we can use list of paths in path.
+```
+output:
+  type: delimited_file
+  props:
+    delimiter: ','
+    path: [path/to/write/output.csv, another-path/to/write/output.csv]
+```
 
 **Header & Footer**
 

--- a/ingen/metadata/metadata.py
+++ b/ingen/metadata/metadata.py
@@ -79,9 +79,13 @@ class MetaData:
         path = props.get("path")
         if path is None:
             return
+        if isinstance(path, str):
+            path = [path]
+
         run_date = self._params_map.get("run_date", date.today())
         path_parser = PathParser(run_date)
-        props["path"] = path_parser.parse(path)
+        parsed_paths = [path_parser.parse(p) for p in path]
+        props["path"] = parsed_paths
 
     def _initialize_output(self):
         output = self._configurations.get("output", {})

--- a/ingen/writer/writer.py
+++ b/ingen/writer/writer.py
@@ -56,25 +56,29 @@ class InterfaceWriter:
             self._df.to_csv(path, sep, header=False, index=InterfaceWriter.SHOW_DATAFRAME_INDEX)
 
     def file_writer(self):
-        path = self._props.get('path')
-        if self._type == 'json':
-            json_writer = OldJSONWriter(self._df, self._type, self._props)
-            json_writer.write()
-        elif self._type == 'json_writer':
-            writer = JSONWriter(self._df, self._props, self._params)
-            writer.write()
-        elif self._type == 'rawdatastore':
-            df_writer = DataFrameWriter(self._df, self._props)
-            df_writer.write()
-        elif self._type == 'excel':
-            self.file_writer_excel(path)
-        elif self._type == 'delimited_file':
-            self.file_writer_delimited(path)
-            if self._apicall:
+        paths = self._props.get('path')
+        if not isinstance(paths, list):
+            paths = [paths]
+
+        for path in paths:
+            if self._type == 'json':
+                json_writer = OldJSONWriter(self._df, self._type, self._props)
+                json_writer.write()
+            elif self._type == 'json_writer':
                 writer = JSONWriter(self._df, self._props, self._params)
-                writer.writecsv()
-        else:
-            logger.error(f'Invalid {self._type} file type')
+                writer.write()
+            elif self._type == 'rawdatastore':
+                df_writer = DataFrameWriter(self._df, self._props)
+                df_writer.write()
+            elif self._type == 'excel':
+                self.file_writer_excel(path)
+            elif self._type == 'delimited_file':
+                self.file_writer_delimited(path)
+                if self._apicall:
+                    writer = JSONWriter(self._df, self._props, self._params)
+                    writer.writecsv()
+            else:
+                logger.error(f'Invalid {self._type} file type')
 
     def get_header(self):
         header = self._props['header']['function']

--- a/test/writer/test_writer.py
+++ b/test/writer/test_writer.py
@@ -276,6 +276,38 @@ class TestWriter(unittest.TestCase):
         writer.write()
         mock_writer.write.assert_called()
 
+    @patch('ingen.writer.writer.OldJSONWriter')
+    def test_file_writer_multiple_paths(self, mock_json_writer):
+        df = Mock()
+        output_type = 'json'
+        props = {
+            'path': ['../output/file1.json', '../output/file2.json'],
+            'type': 'json'
+        }
+
+        writer = InterfaceWriter(df, output_type, props, {})
+        writer.file_writer()
+
+        self.assertEqual(mock_json_writer.call_count, 2)
+        mock_json_writer.assert_any_call(df, output_type, props)
+        mock_json_writer.return_value.write_assert_called()
+
+    @patch('ingen.writer.writer.OldJSONWriter')
+    def test_file_writer_single_path(self, mock_json_writer):
+        # Arrange
+        df = Mock()
+        output_type = 'json'
+        props = {
+            'path': '../output/file1.json',  # path is now a string, not a list
+            'type': 'json'
+        }
+
+        writer = InterfaceWriter(df, output_type, props, {})
+        writer.file_writer()
+
+        self.assertEqual(mock_json_writer.call_count, 1)
+        mock_json_writer.assert_any_call(df, output_type, props)
+        mock_json_writer.return_value.write.assert_called()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], or [CONTRIB]. If a new feature introduces breaking changes for the <project name> or configuration files, please also add [BREAKING]. 

## Description

This enhancement aims to improve the current process of generating output interface files. Currently, when there is a need to generate the output file in multiple locations, the only option is to duplicate the interface configuration and modify the output path for each copy. This approach leads to unnecessary repetition and maintenance overhead.

With this enhancement, we propose adding support for specifying a list of output paths, allowing multiple files to be generated in different locations from a single interface configuration. This would eliminate the need to create duplicate interfaces, simplifying the process and improving efficiency.

Issue can be found here - https://github.com/blackrock/ingen/issues/57

## Changes Made

The changes are made in the writer class which is used to generate the output files and corresponding test cases have been added in test_writer.

## Definition of Done

Before submitting this pull request, please ensure that the following criteria have been met:

- [x] All automated tests have passed successfully.
- [x] All manual tests have passed successfully.
- [x] Code has been reviewed by at least one other team member.
- [x] Code has been properly documented and commented as needed.
- [x] All new and existing code adheres to our project's coding standards.
- [x] All dependencies have been added or removed from the project's README or other documentation as needed.
- [x] Any relevant documentation or help files have been updated to reflect the changes made in this pull request.
- [x] Any necessary database migrations have been run.
- [x] Any relevant UI changes have been reviewed and approved by the UI/UX team.

## Additional Notes

Testing config file - 
![image](https://github.com/user-attachments/assets/97049b51-4bdb-454a-90e9-4c11664d46cb)


Thank you for submitting!