### PR TITLE
[BUGFIX] type check dict in xml_reader

### DIFF
--- a/ingen/reader/xml_file_reader.py
+++ b/ingen/reader/xml_file_reader.py
@@ -28,7 +28,7 @@ class XMLFileReader:
             if root_tag in data[parent_tag]:
                 xml_data = data[parent_tag][root_tag]
                 rows = []
-                if type(xml_data) is collections.OrderedDict:
+                if isinstance(xml_data, (dict, collections.OrderedDict)):
                     obj = xml_data
                     create_rows(rows, obj, columns)
                 else:
@@ -55,10 +55,10 @@ def get_record(obj, name, val_arr):
         if isinstance(obj, list):
             # for each obj in that list print elem
             get_list_record(obj, elem_name, val_arr)
-        elif isinstance(obj, collections.OrderedDict):
+        elif isinstance(obj, (dict, collections.OrderedDict)):
             if isinstance(obj.get(elem_name), str):
                 val_arr.append(obj.get(elem_name))
-            elif isinstance(obj.get(elem_name), collections.OrderedDict):
+            elif isinstance(obj.get(elem_name), (dict, collections.OrderedDict)):
                 val_arr.append(obj.get(elem_name).get('#text'))
             elif isinstance(obj.get(elem_name), type(None)):
                 val_arr.append('')


### PR DESCRIPTION
## Description

An issue was found in xml_reader due to an upgrade in version of xmltodict from 0.12 to 0.14 https://github.com/martinblech/xmltodict/blob/master/CHANGELOG.md. In v 0.13 OrderedDict was dropped in Python >= 3.7.

## Changes Made
To fix this issue, now we typecheck simple python 'dict'.

## Definition of Done

Before submitting this pull request, please ensure that the following criteria have been met:

- [ ] All automated tests have passed successfully.
- [ ] All manual tests have passed successfully.
- [ ] Code has been reviewed by at least one other team member.
- [ ] Code has been properly documented and commented as needed.
- [ ] All new and existing code adheres to our project's coding standards.
- [ ] All dependencies have been added or removed from the project's README or other documentation as needed.
- [ ] Any relevant documentation or help files have been updated to reflect the changes made in this pull request.
- [ ] Any necessary database migrations have been run.
- [ ] Any relevant UI changes have been reviewed and approved by the UI/UX team.


Thank you for submitting!