### PR TITLE
[feature] default delimiter for CSVs

### DIFF
--- a/ingen/reader/file_reader.py
+++ b/ingen/reader/file_reader.py
@@ -25,7 +25,7 @@ class CSVFileReader(Reader):
         dtype = src.get('dtype')
         try:
             result = pd.read_csv(src['file_path'],
-                                 sep=src.get('delimiter'),
+                                 sep=src.get('delimiter', ','),
                                  index_col=False,
                                  skiprows=config['header_size'],
                                  skipfooter=config['trailer_size'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pycryptodome>=3.20.0
 PyMySQL>=1.1.1
 PyYAML>=6.0.2
 xmltodict>=0.12.0
+openpyxl>=3.1.5

--- a/test/reader/test_file_reader.py
+++ b/test/reader/test_file_reader.py
@@ -110,6 +110,30 @@ class TestFileReader(unittest.TestCase):
         )
 
     @patch('ingen.reader.file_reader.pd')
+    def test_default_delimiter_comma(self, mock_pandas):
+        source = {
+            'id': 'test-source',
+            'type': 'file',
+            'file_type': 'delimited_file',
+            # 'delimiter' intentionally omitted to test default
+            'file_path': 'random/path/to/file',
+            'columns': ['first_name', 'last_name']
+        }
+
+        reader = ReaderFactory.get_reader(source)
+        reader.read(source)
+
+        mock_pandas.read_csv.assert_called_with(
+            source['file_path'],
+            sep=',',
+            index_col=False,
+            skiprows=0,
+            skipfooter=0,
+            names=source['columns'],
+            dtype=None
+        )
+
+    @patch('ingen.reader.file_reader.pd')
     def test_column_dtype(self, mock_pandas):
         source = self._src
         reader = ReaderFactory.get_reader(source)


### PR DESCRIPTION
## Description
To make ingen config less verbose I am removing the required `delimiter` config. If this config param is not present comma will be used as the default parameter.

## Changes Made
* Use comma as default parameter
* This PR also adds the missing openpyxl requirement of FileReader

## Definition of Done

Before submitting this pull request, please ensure that the following criteria have been met:

- [ ] All automated tests have passed successfully.
- [ ] All manual tests have passed successfully.
- [ ] Code has been reviewed by at least one other team member.
- [ ] Code has been properly documented and commented as needed.
- [ ] All new and existing code adheres to our project's coding standards.
- [ ] All dependencies have been added or removed from the project's README or other documentation as needed.
- [ ] Any relevant documentation or help files have been updated to reflect the changes made in this pull request.
- [ ] Any necessary database migrations have been run.
- [ ] Any relevant UI changes have been reviewed and approved by the UI/UX team.
