### PR TITLE
fix unit test test_metadata.test_path_without_date

### DIFF
--- a/test/metadata/test_metadata.py
+++ b/test/metadata/test_metadata.py
@@ -162,7 +162,7 @@ class TestMetaData(unittest.TestCase):
 
         output = metadata.output
 
-        expected_path = f"/some/path/name.csv"
+        expected_path = ["/some/path/name.csv"]
         self.assertEqual(expected_path, output.get("props").get("path"))
 
     def test_metadata_validation_action(self):


### PR DESCRIPTION
As part of #57, metadata.output.props.path was changed to a list of strings to support multiple file generation. This unittest wasn't updated. This PR is to fix the unittest. This also raises the need of type checking in ingen overall which we should focus on in the upcoming PRs.