### PR TITLE
feat(backend): thin FastAPI wrapper around the ingen CLI

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,45 @@
+# InGen FastAPI Wrapper
+
+A thin HTTP service that runs `python -m ingen` and returns structured execution results to the
+InGen Studio frontend. It adds no logic to InGen — it shells out to the CLI and parses the output.
+
+## Run
+
+From the **repository root** (so the sample configs' relative paths resolve):
+
+```bash
+pip install -r backend/requirements.txt   # fastapi, uvicorn, pyyaml
+pip install -e .                           # InGen itself (pandas, great_expectations, ...)
+
+uvicorn backend.app.main:app --reload --port 8000
+```
+
+The Next.js dev server (port 3000, legacy Vite port 5173) is allowed via CORS by default.
+
+## Environment
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `INGEN_WORKDIR` | process cwd | Working directory for the `python -m ingen` subprocess (where data/output paths resolve). |
+| `INGEN_RUNS_DIR` | `backend/.runs` | Where RunRecords are persisted (history). |
+| `INGEN_CORS_ORIGINS` | `http://localhost:3000,http://127.0.0.1:3000,http://localhost:3001,http://127.0.0.1:3001,http://localhost:5173,http://127.0.0.1:5173` | Comma-separated allowed origins. |
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/api/health` | Liveness check. |
+| `POST` | `/api/files/upload` | Upload a sample data file; returns a parsed preview (size/type capped). |
+| `POST` | `/api/sources/columns` | Fetch the column names a configured source would produce. |
+| `POST` | `/api/configs/validate` | Schema/cross-reference validation of a YAML config (no run). |
+| `POST` | `/api/runs` | Write YAML to temp, run InGen, return a structured RunRecord. |
+| `GET`  | `/api/runs/history?config_id=` | List past RunRecords. |
+| `GET`  | `/api/runs/{run_id}` | One RunRecord. |
+| `GET`  | `/api/runs/{run_id}/logs` | The run's log lines. |
+| `GET`  | `/api/runs/{run_id}/validation` | The run's validation report. |
+
+## Trust boundary
+
+This wrapper executes whatever the posted config says (file reads, SQL, API calls — InGen's
+nature). It is intended for **local/trusted development**. Authentication, sandboxing, and network
+egress controls are intentionally out of scope here.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+#  InGen FastAPI wrapper package.

--- a/backend/app/columns.py
+++ b/backend/app/columns.py
@@ -1,0 +1,53 @@
+#  InGen wrapper — read a source's column names from its first row (pure logic, no FastAPI import).
+#
+#  Reuses ingen's own SourceFactory + readers so per-type parsing is never reinvented: build the
+#  source, fetch(), hand back df.columns. Works for any configured source — a file path the user
+#  typed (not just uploads), a MySQL query, an API endpoint.
+
+from pathlib import Path
+
+from ingen.data_source.source_factory import SourceFactory
+
+PREVIEW_ROWS = 5  # we only need the header; never read the whole source for "show columns"
+
+
+def source_columns(source: dict, run_date=None) -> dict:
+    """Column names for one source dict (same shape the frontend serializes).
+
+    Returns {"columns": [...]}. Raises on read failure (missing file, bad query, auth) — the route
+    maps that to a 4xx with the message.
+    """
+    if not isinstance(source, dict) or not source.get("type"):
+        raise ValueError("source must be an object with a 'type'")
+
+    # File sources: read only the first few rows for the header — never the whole file.
+    if source.get("type") == "file" and source.get("file_path"):
+        try:
+            from .files import _parse
+        except ImportError:  # run as a script (self-check) — no package context
+            from files import _parse
+        cols, _preview = _parse(Path(source["file_path"]), n=PREVIEW_ROWS)
+        return {"columns": cols}
+
+    # Non-file (mysql/api/json): fall back to ingen's reader.
+    # ponytail: we don't rewrite user SQL to inject LIMIT — a row cap belongs in the source config;
+    #           tighten here if a live DB/API read ever bites.
+    params_map = {"run_date": run_date} if run_date else None
+    src = SourceFactory().parse_source(source, params_map)
+    df = src.fetch()
+    return {"columns": [str(c) for c in df.columns]}
+
+
+if __name__ == "__main__":
+    # Self-check: a CSV file source resolves to its header row.
+    import csv
+    import tempfile
+    from pathlib import Path
+
+    d = Path(tempfile.mkdtemp())
+    p = d / "t.csv"
+    with p.open("w", newline="") as f:
+        csv.writer(f).writerows([["id", "name", "amount"], [1, "a", 10]])
+    out = source_columns({"id": "t", "type": "file", "file_type": "delimited_file", "file_path": str(p)})
+    assert out["columns"] == ["id", "name", "amount"], out["columns"]
+    print("columns.py self-check ok")

--- a/backend/app/files.py
+++ b/backend/app/files.py
@@ -1,0 +1,69 @@
+#  InGen wrapper — file upload + column/preview parsing (pure logic, no FastAPI import).
+#
+#  Saves an uploaded data file under repo-root Data/, parses its header + a few sample rows with
+#  pandas (already a dependency via InGen), and caches the parsed result keyed by content hash so a
+#  re-upload of the same bytes returns instantly without re-reading.
+
+import hashlib
+import json
+from pathlib import Path
+
+import pandas as pd
+
+DATA_DIR = Path("Data")
+CACHE_DIR = DATA_DIR / ".cache"
+PREVIEW_ROWS = 10
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MB — trusted-dev guard against accidental OOM
+ALLOWED_SUFFIXES = {".csv", ".tsv", ".txt", ".xlsx", ".xls", ".json"}
+
+
+def _parse(path: Path, n=PREVIEW_ROWS):
+    """Columns + first n rows, dispatched on extension. Defaults to delimited (csv/tsv/txt)."""
+    suffix = path.suffix.lower()
+    if suffix in (".xlsx", ".xls"):
+        df = pd.read_excel(path, nrows=n)
+    elif suffix == ".json":
+        df = pd.read_json(path).head(n)
+    else:
+        df = pd.read_csv(path, nrows=n, sep=None, engine="python")  # sep=None → csv.Sniffer auto-detects , ; \t |
+    cols = [str(c) for c in df.columns]
+    preview = df.fillna("").astype(str).values.tolist()
+    return cols, preview
+
+
+def save_and_parse(filename: str, content: bytes) -> dict:
+    """Persist to Data/<filename>, parse, cache by content hash. Returns
+    {file_path, columns, preview, cached}."""
+    if len(content) > MAX_UPLOAD_BYTES:
+        raise ValueError(f"File too large ({len(content)} bytes; max {MAX_UPLOAD_BYTES}).")
+    suffix = Path(filename).suffix.lower()
+    if suffix not in ALLOWED_SUFFIXES:
+        raise ValueError(f"Unsupported file type '{suffix}'. Allowed: {', '.join(sorted(ALLOWED_SUFFIXES))}.")
+    DATA_DIR.mkdir(exist_ok=True)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    digest = hashlib.sha256(content).hexdigest()[:16]
+    cache_file = CACHE_DIR / f"{digest}.json"
+    if cache_file.exists():
+        meta = json.loads(cache_file.read_text())
+        meta["cached"] = True
+        return meta
+
+    dest = DATA_DIR / Path(filename).name  # ponytail: strip any path components from the client name
+    dest.write_bytes(content)
+    cols, preview = _parse(dest)
+    meta = {"file_path": dest.as_posix(), "columns": cols, "preview": preview, "cached": False}
+    cache_file.write_text(json.dumps(meta))
+    return meta
+
+
+if __name__ == "__main__":
+    # Self-check: parse a tiny CSV and confirm caching kicks in on identical bytes.
+    sample = b"id,name,amount\n1,a,10\n2,b,20\n"
+    a = save_and_parse("ponytail_selfcheck.csv", sample)
+    assert a["columns"] == ["id", "name", "amount"], a["columns"]
+    assert a["preview"][0] == ["1", "a", "10"], a["preview"]
+    assert a["cached"] is False
+    b = save_and_parse("ponytail_selfcheck_other_name.csv", sample)
+    assert b["cached"] is True, "identical bytes should hit cache"
+    print("files.py self-check ok")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,129 @@
+#  InGen FastAPI wrapper — HTTP surface (thin)
+#
+#  Routes only: parse the request, delegate to the pure modules (schema_validate / runner / store),
+#  return JSON. No business logic here. Run with:
+#     uvicorn backend.app.main:app --reload --port 8000   (from the repo root)
+
+import os
+
+import yaml
+from fastapi import FastAPI, HTTPException, UploadFile, File
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from .runner import execute_run
+from .schema_validate import validate_yaml
+from .store import default_store
+from .files import save_and_parse
+from .columns import source_columns
+
+app = FastAPI(title="InGen Wrapper", version="1.0.0")
+
+# Allow the Next dev server (3000) — and the legacy Vite port — to call the API in development.
+_DEFAULT_ORIGINS = "http://localhost:3000,http://127.0.0.1:3000,http://localhost:3001,http://127.0.0.1:3001,http://localhost:5173,http://127.0.0.1:5173"
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=os.environ.get("INGEN_CORS_ORIGINS", _DEFAULT_ORIGINS).split(","),
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+STORE = default_store()
+WORKDIR = os.environ.get("INGEN_WORKDIR", os.getcwd())
+
+
+class ValidateRequest(BaseModel):
+    yaml: str
+
+
+class RunRequest(BaseModel):
+    yaml: str
+    configId: str | None = None
+    configName: str | None = None
+    run_date: str | None = None
+    interfaces: list[str] | None = None
+    query_params: dict | None = None
+    override_params: dict | None = None
+
+
+@app.get("/api/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/api/files/upload")
+async def upload_file(file: UploadFile = File(...)):
+    content = await file.read()
+    try:
+        return save_and_parse(file.filename, content)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+class ColumnsRequest(BaseModel):
+    source: dict
+    run_date: str | None = None
+
+
+@app.post("/api/sources/columns")
+def fetch_source_columns(req: ColumnsRequest):
+    try:
+        return source_columns(req.source, req.run_date)
+    except Exception as exc:  # missing file, bad query, auth, unknown type → client shows the message
+        raise HTTPException(status_code=400, detail=f"Couldn't read columns: {exc}")
+
+
+@app.post("/api/configs/validate")
+def validate_config(req: ValidateRequest):
+    return validate_yaml(req.yaml)
+
+
+@app.post("/api/runs")
+def create_run(req: RunRequest):
+    try:
+        config = yaml.safe_load(req.yaml) or {}
+    except yaml.YAMLError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid YAML: {exc}")
+    if not isinstance(config, dict):
+        raise HTTPException(status_code=400, detail="YAML must be a mapping.")
+
+    overrides = {
+        "configId": req.configId,
+        "configName": req.configName,
+        "run_date": req.run_date,
+        "interfaces": req.interfaces,
+        "query_params": req.query_params,
+        "override_params": req.override_params,
+    }
+    record = execute_run(req.yaml, overrides, config, workdir=WORKDIR)
+    STORE.save(record)
+    return record
+
+
+@app.get("/api/runs/history")
+def run_history(config_id: str | None = None):
+    return STORE.list(config_id)
+
+
+@app.get("/api/runs/{run_id}")
+def get_run(run_id: str):
+    record = STORE.get(run_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    return record
+
+
+@app.get("/api/runs/{run_id}/logs")
+def get_run_logs(run_id: str):
+    record = STORE.get(run_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    return {"logs": record.get("logs", [])}
+
+
+@app.get("/api/runs/{run_id}/validation")
+def get_run_validation(run_id: str):
+    record = STORE.get(run_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    return record.get("validation", {"results": [], "summary": {"passed": 0, "failed": 0, "warning": 0, "total": 0}})

--- a/backend/app/runner.py
+++ b/backend/app/runner.py
@@ -1,0 +1,206 @@
+#  InGen FastAPI wrapper — execution runner (pure logic, no FastAPI import)
+#
+#  Runs `python -m ingen <config>` as a subprocess and parses its log output into the SAME
+#  structured RunRecord shape the frontend already consumes (runId/stages/logs/validation/timings).
+#  Keeping this free of FastAPI/pydantic means it is unit-testable with plain Python.
+#
+#  Structured-result note: InGen logs to a Python logger and writes files; it does not emit machine
+#  structured results. So stage status is derived best-effort from its log markers ("Generating
+#  interface 'X'", "Successfully generated interface 'X'", "Failed to generate ..."). This is the
+#  documented seam where deeper instrumentation could replace heuristics later.
+
+import re
+import sys
+import tempfile
+import time
+import uuid
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .validation import derive_validation
+
+STAGE_ORDER_BASE = ["read", "pre_process", "format", "validate", "write"]
+
+# Log markers used to infer how far an interface got before failing.
+_STAGE_MARKERS = [
+    ("pre_process", re.compile(r"pre-processing", re.I)),
+    ("format", re.compile(r"Formatting column", re.I)),
+    ("validate", re.compile(r"Validat", re.I)),
+    ("write", re.compile(r"writing file|Successfully generated", re.I)),
+]
+_GEN_RE = re.compile(r"Generating interface '([^']+)'")
+_OK_RE = re.compile(r"Successfully generated interface '([^']+)'")
+_FAIL_RE = re.compile(r"Failed to generate interface file for (\S+)")
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+_LEVEL_RE = re.compile(r"\s-\s(DEBUG|INFO|WARNING|ERROR|CRITICAL)\s-\s")
+_LEVEL_MAP = {"CRITICAL": "error", "ERROR": "error", "WARNING": "warn", "DEBUG": "info", "INFO": "info"}
+
+
+def _level_of(line: str) -> str:
+    """Use ingen's ' - LEVEL - ' log prefix; fall back to a narrow heuristic for prefix-less lines
+    (e.g. raw traceback lines). Avoids flagging data/columns named 'error' as errors."""
+    m = _LEVEL_RE.search(line)
+    if m:
+        return _LEVEL_MAP[m.group(1)]
+    low = line.lower()
+    if "traceback" in low or low.startswith("error"):
+        return "error"
+    return "info"
+
+
+def _stages_for_interface(iface_cfg: dict):
+    stages = ["read", "pre_process"]
+    if iface_cfg.get("post_processing"):
+        stages.append("post_process")
+    stages += ["format", "validate", "write"]
+    return stages
+
+
+def build_run_record(*, config_id, config_name, overrides, started_at, finished_at,
+                     duration_ms, exit_code, output, config: dict):
+    """Turn captured subprocess output into a RunRecord dict (frontend-compatible)."""
+    lines = [ln for ln in output.splitlines() if ln.strip()]
+    interfaces_cfg = config.get("interfaces", {}) or {}
+    requested = overrides.get("interfaces") or list(interfaces_cfg.keys())
+
+    succeeded = set(_OK_RE.findall(output))
+    failed = set(_FAIL_RE.findall(output))
+    # If the process crashed before any per-interface marker, treat all requested as failed.
+    if exit_code != 0 and not succeeded and not failed:
+        failed = set(requested)
+
+    logs = []
+    base_ts = started_at
+    for ln in lines:
+        logs.append({"type": "log", "ts": base_ts, "level": _level_of(ln), "message": ln.strip()})
+
+    stages = []
+    for name in requested:
+        iface_cfg = interfaces_cfg.get(name, {})
+        order = _stages_for_interface(iface_cfg)
+        ok = name in succeeded or (name not in failed and exit_code == 0)
+        if ok:
+            for st in order:
+                stages.append({"interface": name, "stage": st, "status": "ok"})
+            continue
+        # Failed: infer the furthest stage reached from this interface's log slice.
+        reached = _furthest_stage(output, name)
+        reached_idx = order.index(reached) if reached in order else 0
+        for i, st in enumerate(order):
+            if i < reached_idx:
+                status = "ok"
+            elif i == reached_idx:
+                status = "failed"
+            else:
+                status = "skipped"
+            stages.append({"interface": name, "stage": st, "status": status})
+
+    validation = derive_validation(config, requested, failed)
+
+    if not failed:
+        status = "success"
+    elif len(failed) >= len(requested):
+        status = "failed"
+    else:
+        status = "partial"
+
+    return {
+        "runId": f"run_{uuid.uuid4().hex[:10]}",
+        "configId": config_id,
+        "configName": config_name,
+        "status": status,
+        "startedAt": started_at,
+        "finishedAt": finished_at,
+        "durationMs": duration_ms,
+        "stages": stages,
+        "logs": logs,
+        "validation": validation,
+        "overrides": overrides,
+    }
+
+
+def _furthest_stage(output: str, interface: str) -> str:
+    """Best-effort: which stage did `interface` reach before failing? Scans its log slice."""
+    gen = re.search(rf"Generating interface '{re.escape(interface)}'", output)
+    if not gen:
+        return "read"
+    rest = output[gen.end():]
+    nxt = _GEN_RE.search(rest)
+    slice_ = rest[: nxt.start()] if nxt else rest
+    reached = "read"
+    for stage, rx in _STAGE_MARKERS:
+        if rx.search(slice_):
+            reached = stage
+    return reached
+
+
+def _as_param_pairs(params) -> list:
+    """Render a {key: value} override map as a list of `key=value` argv tokens for InGen.
+
+    Returns [] for empty/None so callers can omit the flag entirely. Values are stringified; keys
+    and values are passed through verbatim (InGen splits on the first '=').
+    """
+    if not params:
+        return []
+    return [f"{k}={v}" for k, v in params.items()]
+
+
+def _default_executor(cmd, cwd):
+    """Run the real subprocess. Returns (exit_code, combined_output)."""
+    proc = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, timeout=600,
+    )
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def execute_run(yaml_text: str, overrides: dict, config: dict, *,
+                workdir: str = ".", executor=_default_executor) -> dict:
+    """Write YAML to a temp file, run `python -m ingen`, return a RunRecord dict.
+
+    `executor` is injectable so the parsing/record-building can be unit-tested without InGen/GE.
+    """
+    overrides = overrides or {}
+    config_id = overrides.get("configId") or config.get("_configId") or "config"
+    config_name = overrides.get("configName") or config.get("_configName") or config_id
+
+    started_at = _now_iso()
+    t0 = time.time()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_path = Path(tmp) / "interface.yml"
+        cfg_path.write_text(yaml_text, encoding="utf-8")
+
+        cmd = [sys.executable, "-m", "ingen", str(cfg_path)]
+        if overrides.get("run_date"):
+            cmd.append(str(overrides["run_date"]))
+        if overrides.get("interfaces"):
+            cmd += ["--interfaces", ",".join(overrides["interfaces"])]
+        # InGen's KeyValue argparse action RESETS its dict on every occurrence of the flag, so each
+        # pair must be passed as additional values of ONE flag (`--query_params a=1 b=2`), not as a
+        # repeated flag (`--query_params a=1 --query_params b=2`) which would keep only the last pair.
+        query_pairs = _as_param_pairs(overrides.get("query_params"))
+        if query_pairs:
+            cmd += ["--query_params", *query_pairs]
+        override_pairs = _as_param_pairs(overrides.get("override_params"))
+        if override_pairs:
+            cmd += ["--override_params", *override_pairs]
+
+        try:
+            exit_code, output = executor(cmd, workdir)
+        except Exception as exc:  # subprocess failure, timeout, etc.
+            exit_code, output = 1, f"Wrapper failed to execute InGen: {exc}"
+
+    finished_at = _now_iso()
+    duration_ms = int((time.time() - t0) * 1000)
+
+    return build_run_record(
+        config_id=config_id, config_name=config_name, overrides=overrides,
+        started_at=started_at, finished_at=finished_at, duration_ms=duration_ms,
+        exit_code=exit_code, output=output, config=config,
+    )

--- a/backend/app/schema_validate.py
+++ b/backend/app/schema_validate.py
@@ -1,0 +1,60 @@
+#  InGen FastAPI wrapper — config schema validation (pure logic, no execution)
+#
+#  Lightweight structural checks for POST /api/configs/validate. Returns issues in the same shape
+#  the frontend's ConfigIssue uses ({ level, code, message, path }). Mirrors the integrity rules the
+#  InGen MetaDataParser/SourceFactory rely on, without running the pipeline.
+
+import yaml
+
+from ingen.data_source.data_source_type import DataSourceType
+
+# Source of truth: ingen's own enum. Adding a source type to ingen makes this validator accept it
+# automatically — no parallel list to keep in sync. (Killed the drift the code review flagged.)
+_VALID_SOURCE_TYPES = {e.value for e in DataSourceType}
+
+
+def validate_yaml(yaml_text: str) -> dict:
+    """Parse + structurally validate an InGen config. Returns { valid, issues }."""
+    issues = []
+    try:
+        doc = yaml.safe_load(yaml_text)
+    except yaml.YAMLError as exc:
+        return {"valid": False, "issues": [{
+            "level": "error", "code": "PARSE_ERROR",
+            "message": f"Invalid YAML: {getattr(exc, 'problem', exc)}", "path": "",
+        }]}
+
+    if not isinstance(doc, dict):
+        return {"valid": False, "issues": [{
+            "level": "error", "code": "PARSE_ERROR",
+            "message": "Top-level YAML must be a mapping with sources/interfaces.", "path": "",
+        }]}
+
+    sources = doc.get("sources") or []
+    interfaces = doc.get("interfaces") or {}
+    source_ids = {s.get("id") for s in sources if isinstance(s, dict)}
+
+    if not interfaces:
+        issues.append({"level": "warning", "code": "NO_INTERFACES",
+                       "message": "Config defines no interfaces.", "path": "interfaces"})
+
+    for s in sources:
+        if not isinstance(s, dict) or not s.get("id"):
+            issues.append({"level": "error", "code": "SOURCE_NO_ID",
+                           "message": "A source is missing an id.", "path": "sources"})
+            continue
+        if s.get("type") not in _VALID_SOURCE_TYPES:
+            issues.append({"level": "error", "code": "UNKNOWN_SOURCE_TYPE",
+                           "message": f"Source '{s['id']}' has unsupported type '{s.get('type')}'.",
+                           "path": f"sources.{s['id']}"})
+
+    for name, iface in interfaces.items():
+        iface = iface or {}
+        for sid in iface.get("sources", []) or []:
+            if sid not in source_ids:
+                issues.append({"level": "error", "code": "UNKNOWN_SOURCE_REF",
+                               "message": f"Interface '{name}' references undefined source '{sid}'.",
+                               "path": f"interfaces.{name}.sources"})
+
+    valid = not any(i["level"] == "error" for i in issues)
+    return {"valid": valid, "issues": issues}

--- a/backend/app/store.py
+++ b/backend/app/store.py
@@ -1,0 +1,42 @@
+#  InGen FastAPI wrapper — run history store (pure logic)
+#
+#  Persists RunRecords as JSON files on disk so GET /api/runs/{id} and /api/runs/history survive
+#  restarts. A future swap to a real database keeps the same tiny interface.
+
+import json
+import os
+from pathlib import Path
+
+
+class RunStore:
+    def __init__(self, base_dir: str):
+        self.dir = Path(base_dir)
+        self.dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, run_id: str) -> Path:
+        return self.dir / f"{run_id}.json"
+
+    def save(self, record: dict) -> None:
+        self._path(record["runId"]).write_text(json.dumps(record), encoding="utf-8")
+
+    def get(self, run_id: str):
+        path = self._path(run_id)
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def list(self, config_id: str | None = None):
+        records = []
+        for f in self.dir.glob("run_*.json"):
+            try:
+                records.append(json.loads(f.read_text(encoding="utf-8")))
+            except (OSError, json.JSONDecodeError):
+                continue
+        if config_id:
+            records = [r for r in records if r.get("configId") == config_id]
+        records.sort(key=lambda r: r.get("startedAt", ""), reverse=True)
+        return records
+
+
+def default_store() -> RunStore:
+    return RunStore(os.environ.get("INGEN_RUNS_DIR", str(Path(__file__).resolve().parent.parent / ".runs")))

--- a/backend/app/validation.py
+++ b/backend/app/validation.py
@@ -1,0 +1,46 @@
+#  InGen FastAPI wrapper — validation report derivation (pure logic)
+#
+#  Builds a ValidationReport in the SAME shape the frontend expects
+#  ({ results:[{interface,column,expectation,severity,status,unexpectedCount}], summary }).
+#
+#  Best-effort: InGen runs great_expectations during execution and logs results, but does not emit
+#  structured GE output. So this enumerates the column validations configured in the YAML and marks
+#  status from the run outcome (a failing interface fails/wars its expectations by severity; a
+#  succeeding interface passes them). Replacing this with parsed GE results is the future seam.
+
+
+def _col_name(col: dict) -> str:
+    return col.get("dest_col_name") or col.get("src_col_name") or "(unnamed)"
+
+
+def derive_validation(config: dict, interface_names, failed_interfaces) -> dict:
+    failed_interfaces = set(failed_interfaces or [])
+    interfaces_cfg = config.get("interfaces", {}) or {}
+    results = []
+
+    for name in interface_names:
+        iface = interfaces_cfg.get(name, {})
+        for col in iface.get("columns", []) or []:
+            column = _col_name(col)
+            for v in col.get("validations", []) or []:
+                severity = v.get("severity", "warning")
+                if name in failed_interfaces:
+                    status = "warning" if severity == "warning" else "failed"
+                else:
+                    status = "passed"
+                results.append({
+                    "interface": name,
+                    "column": column,
+                    "expectation": v.get("type"),
+                    "severity": severity,
+                    "status": status,
+                    "unexpectedCount": 0 if status == "passed" else 1,
+                })
+
+    summary = {
+        "passed": sum(1 for r in results if r["status"] == "passed"),
+        "failed": sum(1 for r in results if r["status"] == "failed"),
+        "warning": sum(1 for r in results if r["status"] == "warning"),
+        "total": len(results),
+    }
+    return {"results": results, "summary": summary}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+# InGen FastAPI wrapper dependencies.
+# Install alongside InGen itself (pip install -e . from the repo root, or the built wheel).
+fastapi>=0.110
+uvicorn[standard]>=0.27
+pyyaml>=6.0
+python-multipart>=0.0.9  # multipart file upload (POST /api/files/upload)
+# InGen's own runtime deps (pandas, great_expectations, etc.) come from the InGen package.

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for the InGen FastAPI wrapper (backend/app).

--- a/backend/tests/test_columns.py
+++ b/backend/tests/test_columns.py
@@ -1,0 +1,29 @@
+#  Tests for backend/app/columns.py
+#
+#  source_columns builds an ingen source and returns its column names. Covers the file path and the
+#  bad-input guard; SQL/API need live connections so they're out of scope for a unit test.
+
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+from backend.app.columns import source_columns
+
+
+class SourceColumns(unittest.TestCase):
+    def test_file_source_returns_header(self):
+        d = Path(tempfile.mkdtemp())
+        p = d / "t.csv"
+        with p.open("w", newline="") as f:
+            csv.writer(f).writerows([["id", "name", "amount"], [1, "a", 10]])
+        out = source_columns({"id": "t", "type": "file", "file_type": "delimited_file", "file_path": str(p)})
+        self.assertEqual(out["columns"], ["id", "name", "amount"])
+
+    def test_missing_type_raises(self):
+        with self.assertRaises(ValueError):
+            source_columns({"id": "x"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_runner.py
+++ b/backend/tests/test_runner.py
@@ -1,0 +1,170 @@
+#  Tests for backend/app/runner.py
+#
+#  The runner is the riskiest backend module: it builds the InGen CLI command and infers a structured
+#  RunRecord from unstructured log text. These tests pin (a) the A3 param-emission fix — multiple
+#  query/override params must ride a SINGLE flag, not be repeated — and (b) the status/stage/log
+#  derivation across success / partial / failure / crash, all via an injected fake executor so no real
+#  InGen subprocess runs.
+
+import unittest
+
+from backend.app.runner import (
+    _as_param_pairs,
+    _furthest_stage,
+    build_run_record,
+    execute_run,
+)
+
+
+def _record(output, exit_code, config, overrides=None):
+    return build_run_record(
+        config_id="cfg", config_name="cfg", overrides=overrides or {},
+        started_at="2026-01-01T00:00:00+00:00", finished_at="2026-01-01T00:00:01+00:00",
+        duration_ms=1000, exit_code=exit_code, output=output, config=config,
+    )
+
+
+class AsParamPairs(unittest.TestCase):
+    def test_empty_and_none(self):
+        self.assertEqual(_as_param_pairs(None), [])
+        self.assertEqual(_as_param_pairs({}), [])
+
+    def test_renders_all_pairs(self):
+        self.assertEqual(_as_param_pairs({"a": 1, "b": "x"}), ["a=1", "b=x"])
+
+    def test_value_with_equals_is_preserved(self):
+        # InGen splits on the first '=', so a value containing '=' must survive untouched here.
+        self.assertEqual(_as_param_pairs({"q": "col=1"}), ["q=col=1"])
+
+
+class ExecuteRunCommand(unittest.TestCase):
+    """The A3 regression: every override pair must be passed under ONE flag occurrence."""
+
+    def setUp(self):
+        self.captured = {}
+
+        def fake_executor(cmd, cwd):
+            self.captured["cmd"] = cmd
+            self.captured["cwd"] = cwd
+            return 0, "Successfully generated interface 'A'"
+
+        self.executor = fake_executor
+        self.config = {"interfaces": {"A": {}}}
+
+    def _run(self, overrides):
+        return execute_run("interfaces: {A: {}}\n", overrides, self.config,
+                           workdir="/work", executor=self.executor)
+
+    def test_query_params_single_flag_with_all_pairs(self):
+        self._run({"query_params": {"a": "1", "b": "2"}})
+        cmd = self.captured["cmd"]
+        # Exactly one '--query_params', immediately followed by both pairs.
+        self.assertEqual(cmd.count("--query_params"), 1)
+        idx = cmd.index("--query_params")
+        self.assertEqual(cmd[idx + 1:idx + 3], ["a=1", "b=2"])
+
+    def test_override_params_single_flag_with_all_pairs(self):
+        self._run({"override_params": {"x": "9", "y": "8"}})
+        cmd = self.captured["cmd"]
+        self.assertEqual(cmd.count("--override_params"), 1)
+        idx = cmd.index("--override_params")
+        self.assertEqual(cmd[idx + 1:idx + 3], ["x=9", "y=8"])
+
+    def test_omits_flags_when_no_params(self):
+        self._run({})
+        cmd = self.captured["cmd"]
+        self.assertNotIn("--query_params", cmd)
+        self.assertNotIn("--override_params", cmd)
+
+    def test_interfaces_and_run_date_are_passed(self):
+        self._run({"run_date": "2026-06-16", "interfaces": ["A", "B"]})
+        cmd = self.captured["cmd"]
+        self.assertIn("2026-06-16", cmd)
+        idx = cmd.index("--interfaces")
+        self.assertEqual(cmd[idx + 1], "A,B")
+        self.assertEqual(self.captured["cwd"], "/work")
+
+    def test_executor_exception_is_captured_as_failure(self):
+        def boom(cmd, cwd):
+            raise RuntimeError("subprocess exploded")
+
+        record = execute_run("interfaces: {A: {}}\n", {}, self.config,
+                             workdir="/work", executor=boom)
+        # A crash before any per-interface marker → all requested interfaces marked failed.
+        self.assertEqual(record["status"], "failed")
+        self.assertTrue(any("exploded" in ln["message"] for ln in record["logs"]))
+
+
+class BuildRunRecordStatus(unittest.TestCase):
+    def test_success(self):
+        rec = _record("Generating interface 'A'\nSuccessfully generated interface 'A'", 0,
+                      {"interfaces": {"A": {}}})
+        self.assertEqual(rec["status"], "success")
+        self.assertTrue(all(s["status"] == "ok" for s in rec["stages"]))
+
+    def test_all_failed(self):
+        rec = _record("Failed to generate interface file for A", 0, {"interfaces": {"A": {}}})
+        self.assertEqual(rec["status"], "failed")
+
+    def test_partial(self):
+        out = ("Generating interface 'A'\nSuccessfully generated interface 'A'\n"
+               "Generating interface 'B'\nFailed to generate interface file for B")
+        rec = _record(out, 0, {"interfaces": {"A": {}, "B": {}}})
+        self.assertEqual(rec["status"], "partial")
+
+    def test_crash_before_markers_fails_all_requested(self):
+        rec = _record("Traceback (most recent call last): boom", 1,
+                      {"interfaces": {"A": {}, "B": {}}})
+        self.assertEqual(rec["status"], "failed")
+        self.assertEqual({s["interface"] for s in rec["stages"]}, {"A", "B"})
+
+    def test_logs_capture_level(self):
+        rec = _record("Generating interface 'A'\n2026-01-01 00:00:00 - root - ERROR - boom\n"
+                      "Successfully generated interface 'A'",
+                      0, {"interfaces": {"A": {}}})
+        levels = {ln["level"] for ln in rec["logs"]}
+        self.assertIn("error", levels)
+
+    def test_stage_set_includes_post_process_when_configured(self):
+        rec = _record("Generating interface 'A'\nSuccessfully generated interface 'A'", 0,
+                      {"interfaces": {"A": {"post_processing": [{"type": "pivot"}]}}})
+        stages = {s["stage"] for s in rec["stages"] if s["interface"] == "A"}
+        self.assertIn("post_process", stages)
+
+
+class LevelOf(unittest.TestCase):
+    def test_level_of_uses_log_prefix_not_substring(self):
+        from backend.app.runner import _level_of
+        # A data value containing "error" must NOT be flagged as an error.
+        self.assertEqual(_level_of("2026-01-01 00:00:00 - root - INFO - balance error column loaded"), "info")
+        self.assertEqual(_level_of("2026-01-01 00:00:00 - root - ERROR - boom"), "error")
+        self.assertEqual(_level_of("2026-01-01 00:00:00 - py.warnings - WARNING - FutureWarning"), "warn")
+        self.assertEqual(_level_of("Traceback (most recent call last):"), "error")
+
+
+class FurthestStage(unittest.TestCase):
+    def test_reaches_read_when_no_markers(self):
+        self.assertEqual(_furthest_stage("Generating interface 'A'", "A"), "read")
+
+    def test_reaches_pre_process(self):
+        out = "Generating interface 'A'\nStarting pre-processing now"
+        self.assertEqual(_furthest_stage(out, "A"), "pre_process")
+
+    def test_marker_isolated_to_interface_slice(self):
+        # B's pre-processing marker must not bleed into A's slice.
+        out = ("Generating interface 'A'\n"
+               "Generating interface 'B'\nStarting pre-processing for B")
+        self.assertEqual(_furthest_stage(out, "A"), "read")
+
+    def test_failed_interface_marks_reached_stage_failed_rest_skipped(self):
+        out = "Generating interface 'A'\nStarting pre-processing\nFailed to generate interface file for A"
+        rec = _record(out, 0, {"interfaces": {"A": {}}})
+        by_stage = {s["stage"]: s["status"] for s in rec["stages"]}
+        self.assertEqual(by_stage["read"], "ok")
+        self.assertEqual(by_stage["pre_process"], "failed")
+        self.assertEqual(by_stage["format"], "skipped")
+        self.assertEqual(by_stage["write"], "skipped")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_schema_validate.py
+++ b/backend/tests/test_schema_validate.py
@@ -1,0 +1,58 @@
+#  Tests for backend/app/schema_validate.py
+#
+#  validate_yaml does structural/cross-reference checks (no execution) and returns { valid, issues }.
+#  These tests pin every issue code.
+
+import unittest
+
+from backend.app.schema_validate import validate_yaml
+
+
+def codes(result):
+    return {i["code"] for i in result["issues"]}
+
+
+class ValidateYaml(unittest.TestCase):
+    def test_valid_config(self):
+        res = validate_yaml("sources:\n  - id: s1\n    type: file\ninterfaces:\n  A:\n    sources: [s1]\n")
+        self.assertTrue(res["valid"])
+        self.assertNotIn("UNKNOWN_SOURCE_REF", codes(res))
+
+    def test_invalid_yaml_is_parse_error(self):
+        res = validate_yaml("a: b: c:\n  - : :")
+        self.assertFalse(res["valid"])
+        self.assertEqual(codes(res), {"PARSE_ERROR"})
+
+    def test_non_mapping_top_level(self):
+        res = validate_yaml("- one\n- two\n")
+        self.assertFalse(res["valid"])
+        self.assertEqual(codes(res), {"PARSE_ERROR"})
+
+    def test_no_interfaces_warns_but_is_valid(self):
+        res = validate_yaml("sources:\n  - id: s1\n    type: file\n")
+        self.assertTrue(res["valid"])
+        self.assertIn("NO_INTERFACES", codes(res))
+
+    def test_source_missing_id(self):
+        res = validate_yaml("sources:\n  - type: file\ninterfaces:\n  A: {}\n")
+        self.assertFalse(res["valid"])
+        self.assertIn("SOURCE_NO_ID", codes(res))
+
+    def test_unknown_source_type(self):
+        res = validate_yaml("sources:\n  - id: s1\n    type: ftp\ninterfaces:\n  A: {}\n")
+        self.assertFalse(res["valid"])
+        self.assertIn("UNKNOWN_SOURCE_TYPE", codes(res))
+
+    def test_unknown_source_reference(self):
+        res = validate_yaml("sources:\n  - id: s1\n    type: file\ninterfaces:\n  A:\n    sources: [s2]\n")
+        self.assertFalse(res["valid"])
+        self.assertIn("UNKNOWN_SOURCE_REF", codes(res))
+
+    def test_all_supported_source_types_accepted(self):
+        for t in ("file", "mysql", "api", "json"):
+            res = validate_yaml(f"sources:\n  - id: s1\n    type: {t}\ninterfaces:\n  A: {{}}\n")
+            self.assertNotIn("UNKNOWN_SOURCE_TYPE", codes(res), t)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -1,0 +1,60 @@
+#  Tests for backend/app/store.py
+#
+#  RunStore persists RunRecords as one JSON file each. These tests pin save/get/round-trip, the
+#  missing-id None contract, config filtering, newest-first ordering, and corruption tolerance in
+#  list(). Each test uses an isolated temp directory so nothing touches the real .runs store.
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from backend.app.store import RunStore
+
+
+class RunStoreTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.store = RunStore(self._tmp.name)
+
+    def _rec(self, run_id, config_id="cfg", started_at="2026-01-01T00:00:00+00:00"):
+        return {"runId": run_id, "configId": config_id, "startedAt": started_at, "status": "success"}
+
+    def test_save_and_get_round_trip(self):
+        rec = self._rec("run_a")
+        self.store.save(rec)
+        self.assertEqual(self.store.get("run_a"), rec)
+
+    def test_get_missing_returns_none(self):
+        self.assertIsNone(self.store.get("run_nope"))
+
+    def test_list_filters_by_config_id(self):
+        self.store.save(self._rec("run_a", config_id="x"))
+        self.store.save(self._rec("run_b", config_id="y"))
+        ids = {r["runId"] for r in self.store.list(config_id="x")}
+        self.assertEqual(ids, {"run_a"})
+
+    def test_list_sorted_newest_first(self):
+        self.store.save(self._rec("run_old", started_at="2026-01-01T00:00:00+00:00"))
+        self.store.save(self._rec("run_new", started_at="2026-06-01T00:00:00+00:00"))
+        order = [r["runId"] for r in self.store.list()]
+        self.assertEqual(order, ["run_new", "run_old"])
+
+    def test_list_tolerates_corrupt_files(self):
+        self.store.save(self._rec("run_ok"))
+        # A truncated/garbage file matching the glob must be skipped, not crash list().
+        (Path(self._tmp.name) / "run_bad.json").write_text("{ not valid json", encoding="utf-8")
+        ids = {r["runId"] for r in self.store.list()}
+        self.assertEqual(ids, {"run_ok"})
+
+    def test_creates_directory_if_missing(self):
+        nested = Path(self._tmp.name) / "deep" / "runs"
+        store = RunStore(str(nested))
+        self.assertTrue(nested.exists())
+        store.save(self._rec("run_a"))
+        self.assertEqual(json.loads((nested / "run_a.json").read_text())["runId"], "run_a")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -1,0 +1,67 @@
+#  Tests for backend/app/validation.py
+#
+#  derive_validation enumerates the column validations configured in the YAML and marks each one's
+#  status from the run outcome (failing interface → failed/warning by severity; succeeding → passed).
+#  These tests pin that mapping and the summary tallies, including the column-name fallback chain.
+
+import unittest
+
+from backend.app.validation import derive_validation
+
+
+def _cfg(severity="blocker"):
+    return {
+        "interfaces": {
+            "A": {
+                "columns": [
+                    {"dest_col_name": "c1", "validations": [{"type": "not_null", "severity": severity}]},
+                ]
+            }
+        }
+    }
+
+
+class DeriveValidation(unittest.TestCase):
+    def test_passed_when_interface_succeeds(self):
+        rep = derive_validation(_cfg("blocker"), ["A"], failed_interfaces=set())
+        self.assertEqual(rep["results"][0]["status"], "passed")
+        self.assertEqual(rep["results"][0]["unexpectedCount"], 0)
+        self.assertEqual(rep["summary"], {"passed": 1, "failed": 0, "warning": 0, "total": 1})
+
+    def test_non_warning_severity_fails_when_interface_fails(self):
+        rep = derive_validation(_cfg("blocker"), ["A"], failed_interfaces={"A"})
+        self.assertEqual(rep["results"][0]["status"], "failed")
+        self.assertEqual(rep["results"][0]["unexpectedCount"], 1)
+        self.assertEqual(rep["summary"]["failed"], 1)
+
+    def test_warning_severity_warns_when_interface_fails(self):
+        rep = derive_validation(_cfg("warning"), ["A"], failed_interfaces={"A"})
+        self.assertEqual(rep["results"][0]["status"], "warning")
+        self.assertEqual(rep["summary"]["warning"], 1)
+
+    def test_column_name_fallback_to_src_then_unnamed(self):
+        cfg = {"interfaces": {"A": {"columns": [
+            {"src_col_name": "s1", "validations": [{"type": "t"}]},
+            {"validations": [{"type": "t"}]},
+        ]}}}
+        rep = derive_validation(cfg, ["A"], set())
+        cols = [r["column"] for r in rep["results"]]
+        self.assertEqual(cols, ["s1", "(unnamed)"])
+
+    def test_default_severity_is_warning(self):
+        cfg = {"interfaces": {"A": {"columns": [{"dest_col_name": "c", "validations": [{"type": "t"}]}]}}}
+        rep = derive_validation(cfg, ["A"], set())
+        self.assertEqual(rep["results"][0]["severity"], "warning")
+
+    def test_empty_config_yields_empty_report(self):
+        rep = derive_validation({}, [], set())
+        self.assertEqual(rep["results"], [])
+        self.assertEqual(rep["summary"]["total"], 0)
+
+    def test_interface_without_columns_is_skipped(self):
+        rep = derive_validation({"interfaces": {"A": {}}}, ["A"], set())
+        self.assertEqual(rep["summary"]["total"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `backend/app/` — a thin, local-dev-only FastAPI service that runs the InGen CLI and returns structured results. It contains no business logic: it shells out to `python -m ingen`, parses the CLI's output, and hands JSON back to a frontend (the InGen Studio SPA, not part of this PR).

| Module | Responsibility |
|---|---|
| `main.py` | HTTP routing only — parses requests, delegates, returns JSON |
| `runner.py` | Writes posted YAML to a temp file, runs the CLI as a subprocess, parses real log output into a structured `RunRecord` (per-stage status, timing, log level) |
| `store.py` | Persists `RunRecord`s to `INGEN_RUNS_DIR` for history/lookup |
| `schema_validate.py` / `validation.py` | Validate a config (and surface a run's validation results) without executing it |
| `files.py` | Sample-data upload with size/type caps, reads only file headers for column preview (not the whole file) |
| `columns.py` | Derives the column list a configured data source would produce |

**Deliberately excluded from this PR:** the inChat assistant (`backend/app/chat.py`), which pulls in `torch`/`transformers`/HuggingFace and is a separable concern with its own dependency weight — follow-up PR. `main.py` in this PR has no chat import, no `/api/chat*` routes.

## Trust boundary

This wrapper executes whatever config is posted (file reads, SQL, API calls — that's InGen's nature). It's intended for **local/trusted development** only — no auth, sandboxing, or network egress controls, by design.

## Testing

- `pytest backend/tests/` — 42 passed.
- Verified `backend.app.main` imports cleanly and registers all 9 routes with `torch`/`transformers`/`accelerate`/`safetensors`/`tokenizers`/`huggingface_hub` deliberately blocked at import time (via `sys.meta_path`), proving this PR carries no import-time dependency on the inChat stack even though those packages happened to be present in the test environment.
- End-to-end: booted `uvicorn backend.app.main:app --port 8123`, then:
  - `GET /api/health` → `{"status": "ok"}`
  - `POST /api/configs/validate` with a real config → validated correctly
  - `POST /api/runs` with a real XML-source config → the CLI subprocess ran the full `read → pre_process → format → validate → write` pipeline and the endpoint returned a `RunRecord` with `"status": "success"` and per-stage logs.
- `backend/README.md` had drifted from `main.py` (missing the files/columns endpoints, wrong default CORS ports/origin). Corrected it to describe exactly what this PR ships.

## What it looks like

The full API surface this PR ships, at `/docs` once `uvicorn backend.app.main:app` is running:

![Backend API docs](https://raw.githubusercontent.com/maan-iitd2/ingen/pr-assets/screenshots/06-backend-api-docs.png)

Nine endpoints, no `/api/chat*` — confirming the inChat stack is genuinely absent from this PR, not just unimported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

