### PR TITLE
feat(frontend): adapters, services, state and forms engine

### DIFF
--- a/frontend/src/adapters/httpChatAdapter.js
+++ b/frontend/src/adapters/httpChatAdapter.js
@@ -1,0 +1,41 @@
+//  HttpChatAdapter — sends messages to the real backend chat API.
+//  Implements the same interface as MockChatAdapter.
+
+/** @typedef {{ ops: object[], reply: string }} ChatResult */
+
+export class HttpChatAdapter {
+  /** @param {import('./httpClient.js').HttpClient} client */
+  constructor(client) {
+    this._client = client;
+  }
+
+  /**
+   * @param {string} message
+   * @param {string[]} columns
+   * @param {string} yaml
+   * @param {string} interfaceName
+   * @param {{role: string, content: string}[]} history  recent turns for follow-up context
+   * @returns {Promise<ChatResult>}
+   */
+  async interpret(message, columns = [], yaml = '', interfaceName = '', history = []) {
+    const res = await fetch(`${this._client.baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message, columns, yaml, interface: interfaceName, history }),
+    });
+    if (!res.ok) {
+      const detail = await res.json().catch(() => ({}));
+      throw new Error(detail.detail || `Chat failed (${res.status})`);
+    }
+    const { ops, reply } = await res.json();
+    return {
+      ops: Array.isArray(ops) ? ops : [],
+      reply: typeof reply === 'string' ? reply : '',
+    };
+  }
+
+  /** Fire-and-forget warmup to pre-load the model on the backend. */
+  warmup() {
+    fetch(`${this._client.baseUrl}/api/chat/warmup`, { method: 'POST' }).catch(() => {});
+  }
+}

--- a/frontend/src/adapters/httpClient.js
+++ b/frontend/src/adapters/httpClient.js
@@ -1,0 +1,30 @@
+//  InGen Studio — HTTP client
+//
+//  Thin fetch wrapper shared by the Http* adapters. Base URL comes from NEXT_PUBLIC_API_BASE_URL
+//  (defaults to the local FastAPI wrapper). Surfaces the backend's `detail` message on errors.
+
+const DEFAULT_BASE = '';
+
+export class HttpClient {
+  constructor(baseUrl) {
+    this.baseUrl = (baseUrl != null && baseUrl !== '' ? baseUrl : DEFAULT_BASE).replace(/\/$/, '');
+  }
+
+  async request(method, path, body) {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: body !== undefined ? { 'Content-Type': 'application/json' } : undefined,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      let detail;
+      try { detail = (await res.json())?.detail; } catch { /* non-JSON error body */ }
+      throw new Error(`HTTP ${res.status} on ${path}${detail ? `: ${detail}` : ''}`);
+    }
+    if (res.status === 204) return null;
+    return res.json();
+  }
+
+  get(path) { return this.request('GET', path); }
+  post(path, body) { return this.request('POST', path, body); }
+}

--- a/frontend/src/adapters/httpConfigAdapter.js
+++ b/frontend/src/adapters/httpConfigAdapter.js
@@ -1,0 +1,23 @@
+//  InGen Studio — HTTP ConfigService adapter
+//
+//  Config CRUD has no backend endpoint in scope, so persistence (list/get/create/update/remove) and
+//  YAML import/export are inherited unchanged from the localStorage-backed MockConfigAdapter. Only
+//  `validate` is routed to the FastAPI wrapper (POST /api/configs/validate), which performs the same
+//  schema/cross-reference checks server-side. Same ConfigService interface, so callers don't change.
+
+import { MockConfigAdapter } from './mockConfigAdapter.js';
+import { modelToYaml } from '../serializers/index.js';
+
+export class HttpConfigAdapter extends MockConfigAdapter {
+  constructor(client) {
+    super();
+    this.client = client;
+  }
+
+  /** @param {import('../models/types.js').ConfigModel} model */
+  async validate(model) {
+    const yaml = modelToYaml(model);
+    const res = await this.client.post('/api/configs/validate', { yaml });
+    return res.issues ?? [];
+  }
+}

--- a/frontend/src/adapters/httpHistoryAdapter.js
+++ b/frontend/src/adapters/httpHistoryAdapter.js
@@ -1,0 +1,30 @@
+//  InGen Studio — HTTP HistoryService adapter
+//
+//  Run history is owned by the backend: a run is persisted by POST /api/runs at execution time, so
+//  `add` is a no-op here (avoids double-writing). `list`/`get` read from the wrapper. `clear` has no
+//  backend endpoint in scope and is a no-op (history is server-authoritative in HTTP mode).
+
+import { HistoryService } from '../services/historyService.js';
+
+export class HttpHistoryAdapter extends HistoryService {
+  constructor(client) {
+    super();
+    this.client = client;
+  }
+
+  async list(configId) {
+    return this.client.get(`/api/runs/history?config_id=${encodeURIComponent(configId)}`);
+  }
+
+  async get(runId) {
+    return this.client.get(`/api/runs/${encodeURIComponent(runId)}`);
+  }
+
+  async add() {
+    // No-op: the backend already persisted the run during POST /api/runs.
+  }
+
+  async clear() {
+    // No-op: no delete endpoint in scope; history is backend-owned in HTTP mode.
+  }
+}

--- a/frontend/src/adapters/httpRunAdapter.js
+++ b/frontend/src/adapters/httpRunAdapter.js
@@ -1,0 +1,61 @@
+//  InGen Studio — HTTP RunService adapter
+//
+//  Serializes the model with the SAME serializer the editor uses, POSTs the YAML to the wrapper
+//  (which runs `python -m ingen` and returns a structured RunRecord), then replays the record's
+//  logs and stages through `onEvent` so the live console panels (timeline, log stream) populate
+//  exactly as they do in mock mode. Returns the identical RunRecord shape — components don't change.
+
+import { RunService } from '../services/runService.js';
+import { modelToYaml } from '../serializers/index.js';
+import { makeId } from '../utils/id.js';
+
+export class HttpRunAdapter extends RunService {
+  constructor(client) {
+    super();
+    this.client = client;
+  }
+
+  async simulate(model, overrides = {}, handlers = {}) {
+    const { onEvent, isCancelled } = handlers;
+    const yaml = modelToYaml(model);
+
+    if (isCancelled?.()) {
+      return this._cancelledRecord(model, overrides);
+    }
+
+    const record = await this.client.post('/api/runs', {
+      yaml,
+      configId: model.meta.id,
+      configName: model.meta.name,
+      run_date: overrides.run_date ?? null,
+      interfaces: overrides.interfaces ?? null,
+      query_params: overrides.query_params ?? null,
+      override_params: overrides.override_params ?? null,
+    });
+
+    // Replay backend results as a stream so the UI behaves identically to mock mode.
+    if (onEvent) {
+      (record.logs ?? []).forEach((e) => onEvent(e));
+      (record.stages ?? []).forEach((s) =>
+        onEvent({ type: 'stage', ts: record.startedAt, interface: s.interface, stage: s.stage, status: s.status }));
+    }
+    return record;
+  }
+
+  _cancelledRecord(model, overrides) {
+    const ts = new Date().toISOString();
+    return {
+      runId: makeId('run_cancelled'),
+      configId: model.meta.id,
+      configName: model.meta.name,
+      status: 'failed',
+      startedAt: ts,
+      finishedAt: ts,
+      durationMs: 0,
+      stages: [],
+      logs: [{ type: 'log', ts, level: 'warn', message: 'Run cancelled before submission.' }],
+      validation: { results: [], summary: { passed: 0, failed: 0, warning: 0, total: 0 } },
+      overrides,
+    };
+  }
+}

--- a/frontend/src/adapters/httpValidationAdapter.js
+++ b/frontend/src/adapters/httpValidationAdapter.js
@@ -1,0 +1,40 @@
+//  InGen Studio — HTTP ValidationService adapter
+//
+//  In HTTP mode, real validation RESULTS come from a run (GET /api/runs/{id}/validation, surfaced via
+//  the RunRecord). `evaluate` is a pre-run preview of the expectations configured in the model — it
+//  enumerates them client-side (no execution), matching the ValidationReport shape. This keeps the
+//  ValidationService interface satisfied; the method is not on the HTTP run path (only the mock run
+//  adapter calls evaluate internally).
+
+import { ValidationService } from '../services/validationService.js';
+
+export class HttpValidationAdapter extends ValidationService {
+  constructor(client) {
+    super();
+    this.client = client; // reserved for a future /api/configs/validate-expectations endpoint
+  }
+
+  async evaluate(model, interfaceNames) {
+    const names = interfaceNames?.length ? interfaceNames : model.interfaceOrder;
+    const results = [];
+    for (const name of names) {
+      const iface = model.interfacesByName[name];
+      if (!iface) continue;
+      for (const col of iface.columns ?? []) {
+        const column = col.dest_col_name || col.src_col_name || '(unnamed)';
+        for (const v of col.validations ?? []) {
+          results.push({
+            interface: name,
+            column,
+            expectation: v.type,
+            severity: v.severity ?? 'warning',
+            status: 'passed', // preview only — real status comes from a run
+            unexpectedCount: 0,
+          });
+        }
+      }
+    }
+    const summary = { passed: results.length, failed: 0, warning: 0, total: results.length };
+    return { results, summary };
+  }
+}

--- a/frontend/src/adapters/index.js
+++ b/frontend/src/adapters/index.js
@@ -1,0 +1,64 @@
+//  InGen Studio — adapter selection (the one swap point)
+//
+//  `buildServices(mode)` returns the concrete service set for a given backend mode. Two sets
+//  exist: `mock` (localStorage, no server required) and `http` (the FastAPI wrapper). Both
+//  implement the same service interfaces, so callers work unchanged against either.
+
+import { ADAPTER_MODE } from '../models/constants.js';
+import { MockConfigAdapter } from './mockConfigAdapter.js';
+import { MockCatalogAdapter } from './mockCatalogAdapter.js';
+import { MockValidationAdapter } from './mockValidationAdapter.js';
+import { MockRunAdapter } from './mockRunAdapter.js';
+import { MockHistoryAdapter } from './mockHistoryAdapter.js';
+import { HttpClient } from './httpClient.js';
+import { HttpConfigAdapter } from './httpConfigAdapter.js';
+import { HttpValidationAdapter } from './httpValidationAdapter.js';
+import { HttpRunAdapter } from './httpRunAdapter.js';
+import { HttpHistoryAdapter } from './httpHistoryAdapter.js';
+import { MockChatAdapter } from './mockChatAdapter.js';
+import { HttpChatAdapter } from './httpChatAdapter.js';
+
+/**
+ * @typedef {Object} ServiceSet
+ * @property {import('../services/configService.js').ConfigService} config
+ * @property {import('../services/catalogService.js').CatalogService} catalog
+ * @property {import('../services/validationService.js').ValidationService} validation
+ * @property {import('../services/runService.js').RunService} run
+ * @property {import('../services/historyService.js').HistoryService} history
+ * @property {{ interpret: Function, warmup: Function }} chat
+ */
+
+/**
+ * @param {string} [mode] one of ADAPTER_MODE.*; defaults to MOCK.
+ * @returns {ServiceSet}
+ */
+export function buildServices(mode = ADAPTER_MODE.MOCK) {
+  switch (mode) {
+    case ADAPTER_MODE.MOCK: {
+      const validation = new MockValidationAdapter();
+      return {
+        config: new MockConfigAdapter(),
+        catalog: new MockCatalogAdapter(),
+        validation,
+        run: new MockRunAdapter(validation), // run reuses the same validation service
+        history: new MockHistoryAdapter(),
+        chat: new MockChatAdapter(),
+      };
+    }
+    case ADAPTER_MODE.HTTP: {
+      // Base URL of the FastAPI wrapper; configurable via NEXT_PUBLIC_API_BASE_URL.
+      const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+      const client = new HttpClient(baseUrl);
+      return {
+        config: new HttpConfigAdapter(client), // CRUD via localStorage; validate → backend
+        catalog: new MockCatalogAdapter(),     // catalog is static (backend-derived constants)
+        validation: new HttpValidationAdapter(client),
+        run: new HttpRunAdapter(client),
+        history: new HttpHistoryAdapter(client),
+        chat: new HttpChatAdapter(client),
+      };
+    }
+    default:
+      throw new Error(`Unknown adapter mode "${mode}"`);
+  }
+}

--- a/frontend/src/adapters/mockCatalogAdapter.js
+++ b/frontend/src/adapters/mockCatalogAdapter.js
@@ -1,0 +1,37 @@
+//  InGen Studio — Mock CatalogService adapter
+//
+//  Returns the static catalog assembled from the backend-derived registries in models/constants.js.
+//  Real and final: these values match the backend today, so this adapter survives into production
+//  unless the catalog is ever moved server-side.
+
+import { CatalogService } from '../services/catalogService.js';
+import {
+  SOURCE_TYPES,
+  FILE_TYPES,
+  PRE_PROCESSOR_TYPES,
+  POST_PROCESSOR_TYPES,
+  FORMATTER_TYPES,
+  VALIDATION_TYPES,
+  VALIDATION_SEVERITIES,
+  OUTPUT_TYPES,
+  INTERPOLATORS,
+} from '../models/constants.js';
+
+/** @typedef {import('../services/catalogService.js').Catalog} Catalog */
+
+export class MockCatalogAdapter extends CatalogService {
+  /** @returns {Promise<Catalog>} */
+  async getCatalog() {
+    return {
+      sourceTypes: Object.values(SOURCE_TYPES),
+      fileTypes: Object.values(FILE_TYPES),
+      preProcessors: Object.values(PRE_PROCESSOR_TYPES),
+      postProcessors: Object.values(POST_PROCESSOR_TYPES),
+      formatters: [...FORMATTER_TYPES],
+      validations: { builtin: [...VALIDATION_TYPES.BUILTIN], custom: [...VALIDATION_TYPES.CUSTOM] },
+      validationSeverities: Object.values(VALIDATION_SEVERITIES),
+      outputTypes: Object.values(OUTPUT_TYPES),
+      interpolators: { static: [...INTERPOLATORS.STATIC], runtime: [...INTERPOLATORS.RUNTIME] },
+    };
+  }
+}

--- a/frontend/src/adapters/mockChatAdapter.js
+++ b/frontend/src/adapters/mockChatAdapter.js
@@ -1,0 +1,20 @@
+//  MockChatAdapter — returns regex-parsed ops without network, matching the ChatService interface.
+//  Used when ADAPTER_MODE is MOCK (no backend).
+
+/** @typedef {{ ops: object[], reply: string }} ChatResult */
+
+export class MockChatAdapter {
+  /**
+   * Interpret a user message as pipeline edit ops.
+   * In mock mode, always throws so the caller falls back to its local regex parser.
+   * Accepts the same arguments as HttpChatAdapter.interpret
+   * (message, columns, yaml, interfaceName, history) but ignores all of them.
+   * @returns {Promise<ChatResult>}
+   */
+  async interpret() {
+    throw new Error('LLM unavailable (mock mode) — using regex fallback');
+  }
+
+  /** No-op in mock mode. */
+  warmup() {}
+}

--- a/frontend/src/adapters/mockConfigAdapter.js
+++ b/frontend/src/adapters/mockConfigAdapter.js
@@ -1,0 +1,101 @@
+//  InGen Studio — Mock ConfigService adapter
+//
+//  Implements the ConfigService contract against the browser's localStorage. This is REAL
+//  persistence: configs created/edited here survive reloads. YAML import/export delegate to the
+//  real serializers, and validation to the pure model validator — so the only thing "mock" about
+//  this adapter is the storage backend. Swapping it for HttpConfigAdapter, which calls the FastAPI
+//  wrapper, requires no change to callers.
+
+import { ConfigService } from '../services/configService.js';
+import { STORAGE_NAMESPACE } from '../models/constants.js';
+import { validateConfigModel } from '../models/configModel.js';
+import { modelToYaml, yamlToModel } from '../serializers/index.js';
+
+/** @typedef {import('../models/types.js').ConfigModel} ConfigModel */
+/** @typedef {import('../services/configService.js').ConfigSummary} ConfigSummary */
+
+const STORE_KEY = `${STORAGE_NAMESPACE}:configs`;
+
+/** Read the full id→ConfigModel map from localStorage (tolerant of missing/corrupt data). */
+function readStore() {
+  if (typeof localStorage === 'undefined') return {};
+  try {
+    const raw = localStorage.getItem(STORE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Persist the full id→ConfigModel map. */
+function writeStore(store) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORE_KEY, JSON.stringify(store));
+}
+
+/** Deep clone so callers can't mutate persisted state by reference. */
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export class MockConfigAdapter extends ConfigService {
+  /** @returns {Promise<ConfigSummary[]>} */
+  async list() {
+    const store = readStore();
+    return Object.values(store)
+      .map((m) => ({
+        id: m.meta.id,
+        name: m.meta.name,
+        updatedAt: m.meta.updatedAt,
+        interfaceCount: m.interfaceOrder?.length ?? 0,
+      }))
+      .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+  }
+
+  /** @param {string} id @returns {Promise<ConfigModel>} */
+  async get(id) {
+    const store = readStore();
+    const model = store[id];
+    if (!model) throw new Error(`Config "${id}" not found`);
+    return clone(model);
+  }
+
+  /** @param {ConfigModel} model @returns {Promise<ConfigModel>} */
+  async create(model) {
+    const store = readStore();
+    if (store[model.meta.id]) throw new Error(`Config "${model.meta.id}" already exists`);
+    store[model.meta.id] = clone(model);
+    writeStore(store);
+    return clone(model);
+  }
+
+  /** @param {ConfigModel} model @returns {Promise<ConfigModel>} */
+  async update(model) {
+    const store = readStore();
+    store[model.meta.id] = clone(model);
+    writeStore(store);
+    return clone(model);
+  }
+
+  /** @param {string} id @returns {Promise<void>} */
+  async remove(id) {
+    const store = readStore();
+    delete store[id];
+    writeStore(store);
+  }
+
+  /** @param {ConfigModel} model */
+  async validate(model) {
+    return validateConfigModel(model);
+  }
+
+  /** @param {string} yamlText @returns {Promise<ConfigModel>} */
+  async importYaml(yamlText) {
+    return yamlToModel(yamlText);
+  }
+
+  /** @param {ConfigModel} model @returns {Promise<string>} */
+  async exportYaml(model) {
+    return modelToYaml(model);
+  }
+}

--- a/frontend/src/adapters/mockHistoryAdapter.js
+++ b/frontend/src/adapters/mockHistoryAdapter.js
@@ -1,0 +1,45 @@
+//  Mock HistoryService — persists RunRecords in localStorage, namespaced per app. Real persistence
+//  (survives reloads). A future HttpHistoryAdapter swaps the storage for the wrapper's runs endpoint.
+
+import { HistoryService } from '../services/historyService.js';
+import { STORAGE_NAMESPACE } from '../models/constants.js';
+
+const KEY = `${STORAGE_NAMESPACE}:runs`;
+
+function readAll() {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeAll(records) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(KEY, JSON.stringify(records));
+}
+
+export class MockHistoryAdapter extends HistoryService {
+  async list(configId) {
+    return readAll()
+      .filter((r) => r.configId === configId)
+      .sort((a, b) => (a.startedAt < b.startedAt ? 1 : -1));
+  }
+
+  async get(runId) {
+    return readAll().find((r) => r.runId === runId) ?? null;
+  }
+
+  async add(record) {
+    const all = readAll();
+    all.push(record);
+    // Keep the store bounded (most recent 100 runs).
+    writeAll(all.slice(-100));
+  }
+
+  async clear(configId) {
+    writeAll(readAll().filter((r) => r.configId !== configId));
+  }
+}

--- a/frontend/src/adapters/mockRunAdapter.js
+++ b/frontend/src/adapters/mockRunAdapter.js
@@ -1,0 +1,126 @@
+//  Mock RunService — simulates `python -m ingen` over the configured model. It walks the real
+//  generate() stage order per interface (read → pre_process → [post_process] → format → validate →
+//  write), streaming timestamped log lines and stage transitions through onEvent, and resolves with
+//  a RunRecord. Validation outcomes come from the ValidationService so the run reflects the actual
+//  configured expectations (incl. blocker abort / critical row-drop semantics).
+
+import { RunService } from '../services/runService.js';
+import { makeId } from '../utils/id.js';
+import { MockValidationAdapter } from './mockValidationAdapter.js';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const now = () => new Date().toISOString();
+
+const STAGE_LABEL = {
+  read: 'Reading sources',
+  pre_process: 'Pre-processing',
+  post_process: 'Post-processing',
+  format: 'Formatting',
+  validate: 'Validation',
+  write: 'Writing output',
+};
+
+export class MockRunAdapter extends RunService {
+  constructor(validationService = new MockValidationAdapter()) {
+    super();
+    this.validation = validationService;
+  }
+
+  async simulate(model, overrides = {}, handlers = {}) {
+    const { onEvent, isCancelled } = handlers;
+    const startedAt = now();
+    const startMs = Date.now();
+    const logs = [];
+    const stages = [];
+
+    const emit = (e) => {
+      const evt = { ts: now(), ...e };
+      logs.push(evt);
+      onEvent?.(evt);
+    };
+
+    const selected = overrides.interfaces?.length
+      ? model.interfaceOrder.filter((n) => overrides.interfaces.includes(n))
+      : model.interfaceOrder;
+
+    const validation = await this.validation.evaluate(model, selected);
+
+    emit({ type: 'log', level: 'info', message: `Run started for "${model.meta.name}" (${selected.length} interface(s))` });
+    if (overrides.run_date) emit({ type: 'log', level: 'info', message: `run_date = ${overrides.run_date}` });
+
+    let aborted = 0;
+    let cancelled = false;
+
+    for (const name of selected) {
+      if (isCancelled?.()) { cancelled = true; break; }
+      const iface = model.interfacesByName[name];
+      emit({ type: 'log', level: 'info', interface: name, message: `Generating interface '${name}'` });
+
+      const order = ['read', 'pre_process'];
+      if (iface.post_processing?.length) order.push('post_process');
+      order.push('format', 'validate', 'write');
+
+      let interfaceAborted = false;
+      for (const stage of order) {
+        if (isCancelled?.()) { cancelled = true; break; }
+        if (interfaceAborted) { stages.push({ interface: name, stage, status: 'skipped', durationMs: 0 }); continue; }
+
+        const t0 = Date.now();
+        emit({ type: 'stage', interface: name, stage, status: 'running' });
+        emit({ type: 'log', level: 'info', interface: name, stage, message: `${STAGE_LABEL[stage]}…` });
+        await sleep(110 + Math.floor(Math.random() * 90));
+
+        let status = 'ok';
+        if (stage === 'read') {
+          emit({ type: 'log', level: 'info', interface: name, stage, message: `Read ${iface.sources?.length ?? 0} source(s)` });
+        } else if (stage === 'validate') {
+          const rs = validation.results.filter((r) => r.interface === name);
+          const blocker = rs.some((r) => r.status === 'failed' && r.severity === 'blocker');
+          const failed = rs.some((r) => r.status === 'failed');
+          const warned = rs.some((r) => r.status === 'warning');
+          if (blocker) {
+            status = 'failed';
+            interfaceAborted = true;
+            emit({ type: 'log', level: 'error', interface: name, stage, message: 'Blocker validation failed — aborting interface' });
+          } else if (failed || warned) {
+            status = 'warning';
+            emit({ type: 'log', level: 'warn', interface: name, stage, message: `${rs.filter((r) => r.status !== 'passed').length} expectation(s) flagged` });
+          } else {
+            emit({ type: 'log', level: 'info', interface: name, stage, message: `${rs.length} expectation(s) passed` });
+          }
+        } else if (stage === 'write') {
+          const out = iface.output?.type ?? 'none';
+          emit({ type: 'log', level: 'info', interface: name, stage, message: `Wrote output (${out})` });
+        }
+
+        emit({ type: 'stage', interface: name, stage, status });
+        stages.push({ interface: name, stage, status, durationMs: Date.now() - t0 });
+      }
+
+      if (interfaceAborted) aborted += 1;
+      if (cancelled) break;
+    }
+
+    const finishedAt = now();
+    const durationMs = Date.now() - startMs;
+    let status = 'success';
+    if (cancelled || aborted === selected.length) status = 'failed';
+    else if (aborted > 0) status = 'partial';
+
+    emit({ type: 'log', level: status === 'success' ? 'info' : 'warn', message: `Run ${status} in ${(durationMs / 1000).toFixed(2)}s` });
+
+    return {
+      runId: makeId('run'),
+      configId: model.meta.id,
+      configName: model.meta.name,
+      status,
+      startedAt,
+      finishedAt,
+      durationMs,
+      stages,
+      logs,
+      validation,
+      overrides,
+    };
+  }
+}

--- a/frontend/src/adapters/mockValidationAdapter.js
+++ b/frontend/src/adapters/mockValidationAdapter.js
@@ -1,0 +1,54 @@
+//  Mock ValidationService — derives deterministic, realistic results from the column validations
+//  actually configured in the model. No execution. A stable string hash decides pass/fail so the
+//  same config yields the same report (good for demos and history comparisons).
+
+import { ValidationService } from '../services/validationService.js';
+
+/** Stable 0..1 pseudo-random from a string. */
+function seed01(str) {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return ((h >>> 0) % 1000) / 1000;
+}
+
+export class MockValidationAdapter extends ValidationService {
+  async evaluate(model, interfaceNames) {
+    const names = interfaceNames?.length ? interfaceNames : model.interfaceOrder;
+    /** @type {import('../services/validationService.js').ValidationResult[]} */
+    const results = [];
+
+    for (const name of names) {
+      const iface = model.interfacesByName[name];
+      if (!iface) continue;
+      for (const col of iface.columns ?? []) {
+        const column = col.dest_col_name || col.src_col_name || '(unnamed)';
+        for (const v of col.validations ?? []) {
+          const severity = v.severity ?? 'warning';
+          const r = seed01(`${name}:${column}:${v.type}`);
+          const fails = r > 0.7; // ~30% fail rate
+          let status = 'passed';
+          if (fails) status = severity === 'warning' ? 'warning' : 'failed';
+          results.push({
+            interface: name,
+            column,
+            expectation: v.type,
+            severity,
+            status,
+            unexpectedCount: fails ? Math.ceil(r * 20) : 0,
+          });
+        }
+      }
+    }
+
+    const summary = {
+      passed: results.filter((x) => x.status === 'passed').length,
+      failed: results.filter((x) => x.status === 'failed').length,
+      warning: results.filter((x) => x.status === 'warning').length,
+      total: results.length,
+    };
+    return { results, summary };
+  }
+}

--- a/frontend/src/forms/SchemaForm.jsx
+++ b/frontend/src/forms/SchemaForm.jsx
@@ -1,0 +1,74 @@
+//  InGen Studio — SchemaForm
+//
+//  Renders a form from a compact field-descriptor array, so source/pre-processor/formatter/output
+//  forms are data, not bespoke JSX. Adding a backend field later = add a descriptor entry. This
+//  schema-driven approach is the main defense against form duplication.
+//
+//  Descriptor: { key, label, kind, options?, optionsFrom?, placeholder?, help?, fields?, rows? }
+//  kind ∈ text | number | select | tags | textarea | toggle | json | group
+//  Dynamic option lists (e.g. sibling source ids) are resolved from `ctx` via `optionsFrom`.
+
+import {
+  TextField, NumberField, SelectField, TextAreaField, ToggleField, TagsField, JsonField,
+} from './fields/Fields.jsx';
+
+function resolveOptions(field, ctx) {
+  if (field.options) return field.options;
+  if (field.optionsFrom && ctx?.[field.optionsFrom]) return ctx[field.optionsFrom];
+  return [];
+}
+
+function FieldRenderer({ field, value, onChange, ctx }) {
+  const common = { label: field.label, help: field.help, value, onChange, placeholder: field.placeholder };
+  switch (field.kind) {
+    case 'number': return <NumberField {...common} />;
+    case 'select': return <SelectField {...common} options={resolveOptions(field, ctx)} />;
+    case 'tags': return <TagsField {...common} />;
+    case 'textarea': return <TextAreaField {...common} rows={field.rows} />;
+    case 'toggle': return <ToggleField {...common} />;
+    case 'json': return <JsonField {...common} rows={field.rows} />;
+    case 'group':
+      return (
+        <fieldset className="field__group">
+          <legend className="field__grouplabel">{field.label}</legend>
+          <SchemaForm
+            schema={field.fields}
+            value={value && typeof value === 'object' ? value : {}}
+            onChange={onChange}
+            ctx={ctx}
+          />
+        </fieldset>
+      );
+    case 'text':
+    default:
+      return <TextField {...common} />;
+  }
+}
+
+/**
+ * @param {{ schema: any[], value: object, onChange: (v:object)=>void, ctx?: object }} props
+ */
+export default function SchemaForm({ schema, value, onChange, ctx }) {
+  const obj = value && typeof value === 'object' ? value : {};
+  return (
+    <div className="schemaform">
+      {schema.map((field) => {
+        if (field.visibleIf && !field.visibleIf(obj)) return null;
+        return (
+          <FieldRenderer
+            key={field.key}
+            field={field}
+            ctx={ctx}
+            value={obj[field.key]}
+            onChange={(v) => {
+              const next = { ...obj };
+              if (v === undefined) delete next[field.key];
+              else next[field.key] = v;
+              onChange(next);
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/forms/fields/Fields.jsx
+++ b/frontend/src/forms/fields/Fields.jsx
@@ -1,0 +1,143 @@
+//  InGen Studio — form field primitives
+//
+//  Small, controlled inputs used by the schema-driven SchemaForm and by bespoke editors. Each takes
+//  a value + onChange and renders a labelled control. Kept deliberately plain (Phase focus is
+//  function, not polish). TagsField/JsonField handle the array/object cases the InGen YAML needs.
+
+import { useState, useEffect, useRef } from 'react';
+
+export function Field({ label, help, children }) {
+  return (
+    <label className="field">
+      {label && <span className="field__label">{label}</span>}
+      {children}
+      {help && <span className="field__help">{help}</span>}
+    </label>
+  );
+}
+
+export function TextField({ label, help, value, onChange, placeholder }) {
+  return (
+    <Field label={label} help={help}>
+      <input
+        className="field__input"
+        value={value ?? ''}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value === '' ? undefined : e.target.value)}
+      />
+    </Field>
+  );
+}
+
+export function NumberField({ label, help, value, onChange, placeholder }) {
+  return (
+    <Field label={label} help={help}>
+      <input
+        className="field__input"
+        type="number"
+        value={value ?? ''}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value === '' ? undefined : Number(e.target.value))}
+      />
+    </Field>
+  );
+}
+
+export function SelectField({ label, help, value, onChange, options, allowEmpty = true }) {
+  return (
+    <Field label={label} help={help}>
+      <select
+        className="field__input"
+        value={value ?? ''}
+        onChange={(e) => onChange(e.target.value === '' ? undefined : e.target.value)}
+      >
+        {allowEmpty && <option value="">—</option>}
+        {options.map((opt) => {
+          const v = typeof opt === 'string' ? opt : opt.value;
+          const l = typeof opt === 'string' ? opt : opt.label;
+          return <option key={v} value={v}>{l}</option>;
+        })}
+      </select>
+    </Field>
+  );
+}
+
+export function TextAreaField({ label, help, value, onChange, placeholder, rows = 3 }) {
+  return (
+    <Field label={label} help={help}>
+      <textarea
+        className="field__input field__input--area"
+        rows={rows}
+        value={value ?? ''}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value === '' ? undefined : e.target.value)}
+      />
+    </Field>
+  );
+}
+
+export function ToggleField({ label, help, value, onChange }) {
+  return (
+    <label className="field field--toggle">
+      <input type="checkbox" checked={Boolean(value)} onChange={(e) => onChange(e.target.checked)} />
+      <span className="field__label">{label}</span>
+      {help && <span className="field__help">{help}</span>}
+    </label>
+  );
+}
+
+/** Comma/whitespace separated string[] — used for column lists, keys, etc. */
+export function TagsField({ label, help, value, onChange, placeholder }) {
+  const text = Array.isArray(value) ? value.join(', ') : '';
+  return (
+    <Field label={label} help={help || 'comma-separated'}>
+      <input
+        className="field__input"
+        value={text}
+        placeholder={placeholder}
+        onChange={(e) => {
+          const arr = e.target.value.split(',').map((s) => s.trim()).filter(Boolean);
+          onChange(arr.length ? arr : undefined);
+        }}
+      />
+    </Field>
+  );
+}
+
+/**
+ * Free-form JSON value (object/array) for the long-tail of advanced fields. Keeps a local text
+ * buffer (initialized from value) so intermediate invalid typing doesn't clobber the model and the
+ * cursor isn't disturbed by reformatting; commits only valid JSON. The buffer is the source of
+ * truth while mounted — callers that need to reset it pass a distinct React `key`.
+ */
+export function JsonField({ label, help, value, onChange, rows = 3 }) {
+  const [text, setText] = useState(() => (value === undefined ? '' : JSON.stringify(value, null, 2)));
+  const [error, setError] = useState(false);
+  const lastCommitted = useRef(value);
+
+  // Sync buffer when value changes externally (e.g. undo/redo) — only when the current
+  // buffer is already valid (not mid-typing) and the new value differs from what we last wrote.
+  useEffect(() => {
+    if (value === lastCommitted.current) return;
+    lastCommitted.current = value;
+    setText(value === undefined ? '' : JSON.stringify(value, null, 2));
+    setError(false);
+  }, [value]);
+
+  return (
+    <Field label={label} help={help || 'JSON'}>
+      <textarea
+        className={`field__input field__input--area mono${error ? ' field__input--err' : ''}`}
+        rows={rows}
+        value={text}
+        onChange={(e) => {
+          const t = e.target.value;
+          setText(t);
+          if (t.trim() === '') { setError(false); lastCommitted.current = undefined; onChange(undefined); return; }
+          try { const parsed = JSON.parse(t); lastCommitted.current = parsed; onChange(parsed); setError(false); } catch { setError(true); }
+        }}
+      />
+      {error && <span className="field__help field__help--err">Invalid JSON — not saved</span>}
+    </Field>
+  );
+}

--- a/frontend/src/forms/schemas/formatterSchemas.js
+++ b/frontend/src/forms/schemas/formatterSchemas.js
@@ -1,0 +1,143 @@
+//  Formatter `format` descriptors. Derived from ingen/formatters/common_formatters.py.
+//  Every backend formatter type has an entry here. Types with no configurable args use `none`.
+//  Types with structured config use `group`. Simple scalar values use `txt`. JSON fallback only
+//  for types where the schema is legitimately arbitrary (get_running_environment, constant_condition).
+
+const txt = (placeholder) => [{ key: 'format', label: 'format', kind: 'text', placeholder }];
+const none = [];
+const jsonFmt = (rows = 2, help) => [{ key: 'format', label: 'format', kind: 'json', rows, help }];
+const group = (fields) => [{ key: 'format', label: 'format', kind: 'group', fields }];
+
+export const FORMATTER_FORMS = {
+  // ── Date / Time ──────────────────────────────────────────────────────────
+  date: group([
+    { key: 'src', label: 'Source format', kind: 'text', placeholder: '%Y-%m-%d', help: 'Use "ms" for epoch milliseconds' },
+    { key: 'des', label: 'Output format', kind: 'text', placeholder: '%m/%d/%Y' },
+  ]),
+  runtime_date: group([
+    { key: 'des', label: 'Output format', kind: 'text', placeholder: '%Y%m%d', help: 'Formats the --run_date CLI argument' },
+  ]),
+  'constant-date': jsonFmt(1, '[day_offset, "%Y%m%d", "US"]  — offset days from run_date, format, holiday calendar'),
+  bus_day: group([
+    { key: 'col', label: 'Date column', kind: 'text' },
+    { key: 'format', label: 'Date format', kind: 'text', placeholder: '%Y-%m-%d' },
+    { key: 'cal', label: 'Holiday calendar', kind: 'text', placeholder: 'US', help: 'Country code for pandas_market_calendars' },
+  ]),
+  last_date_of_prev_month: group([
+    { key: 'outdate_format', label: 'Output format', kind: 'text', placeholder: '%Y%m%d' },
+  ]),
+  current_timestamp: none,
+
+  // ── Numbers ──────────────────────────────────────────────────────────────
+  float: txt('${:,.2f}'),
+  float_precision: group([
+    { key: 'precision', label: 'Decimal places', kind: 'number' },
+  ]),
+  arithmetic_calc: group([
+    { key: 'cols', label: 'Columns', kind: 'tags', help: 'Two columns for binary ops; one for abs' },
+    { key: 'operation', label: 'Operation', kind: 'select', options: ['add', 'sub', 'mul', 'div', 'abs'] },
+    { key: 'value', label: 'Constant value', kind: 'number', help: 'Optional scalar operand' },
+  ]),
+  'group-percentage': group([
+    { key: 'of', label: 'Numerator column', kind: 'text', help: 'Column whose value is the numerator' },
+    { key: 'in', label: 'Group-by column', kind: 'text', help: 'Column that defines each group total' },
+  ]),
+  sum: [{ key: 'format', label: 'Columns to sum', kind: 'tags' }],
+  bucket: group([
+    { key: 'buckets', label: 'Bin edges', kind: 'json', rows: 1, help: '[0, 30, 90, 365, "inf"]' },
+    { key: 'labels', label: 'Labels', kind: 'tags', help: 'One fewer label than edges' },
+    { key: 'include_right', label: 'Include right edge', kind: 'toggle' },
+  ]),
+  add_trailing_zeros: group([
+    { key: 'num_of_chars', label: 'Total width (zero-pad left)', kind: 'number' },
+  ]),
+  index_counter: none,
+
+  // ── Strings ──────────────────────────────────────────────────────────────
+  constant: txt('literal value to set'),
+  concat: group([
+    { key: 'columns', label: 'Columns', kind: 'tags', help: 'Joined in order with separator' },
+    { key: 'separator', label: 'Separator', kind: 'text', placeholder: '' },
+  ]),
+  prefix_string: group([
+    { key: 'columns', label: 'Source columns', kind: 'tags', help: 'Values from these columns are concatenated before the destination column value' },
+    { key: 'prefix', label: 'Literal prefix', kind: 'text' },
+    { key: 'separator', label: 'Separator', kind: 'text', placeholder: '' },
+  ]),
+  suffix_string: group([
+    { key: 'columns', label: 'Source columns', kind: 'tags' },
+    { key: 'suffix', label: 'Literal suffix', kind: 'text' },
+    { key: 'separator', label: 'Separator', kind: 'text', placeholder: '' },
+  ]),
+  sub_string: group([
+    { key: 'start', label: 'Start index', kind: 'number' },
+    { key: 'end', label: 'End index', kind: 'number' },
+  ]),
+  add_space: group([
+    { key: 'spacing', label: 'Total width (left-justify)', kind: 'number' },
+  ]),
+  split_col: group([
+    { key: 'new_col_names', label: 'New column names', kind: 'tags', help: 'One name per split segment' },
+    { key: 'delimiter', label: 'Delimiter', kind: 'text', placeholder: ',' },
+  ]),
+  extract_from_pattern: group([
+    { key: 'pattern', label: 'Regex pattern', kind: 'text', placeholder: '([A-Z]{2}\\d{6})' },
+  ]),
+  decode_bytes: group([
+    { key: 'encoding', label: 'Encoding', kind: 'text', placeholder: 'utf-8' },
+    { key: 'strip_whitespace', label: 'Strip whitespace', kind: 'toggle' },
+  ]),
+
+  // ── Replace / Fill ───────────────────────────────────────────────────────
+  replace_value: group([
+    { key: 'from_value', label: 'From values', kind: 'tags', help: 'Parallel list with "To values"' },
+    { key: 'to_value', label: 'To values', kind: 'tags' },
+    { key: 'replace_missing', label: 'Replace missing (None/NaN)', kind: 'toggle', help: 'When on and From value is null, fills NaN cells with the To value' },
+    { key: 'search_list', label: 'Search inside list cells', kind: 'toggle', help: 'Also replaces matching elements inside list-typed cells' },
+  ]),
+  fill_empty_values: group([
+    { key: 'column', label: 'Fill-from column', kind: 'text', help: 'When destination cell is empty, copy value from this column' },
+  ]),
+  fill_empty_values_with_custom_value: group([
+    { key: 'value', label: 'Fill value', kind: 'text' },
+    { key: 'condition', label: 'Condition', kind: 'group', fields: [
+      { key: 'match_col', label: 'Match column', kind: 'text' },
+      { key: 'pattern', label: 'Regex pattern', kind: 'text' },
+    ] },
+  ]),
+  conditional_replace_formatter: group([
+    { key: 'from_column', label: 'Source column', kind: 'text', help: 'Copy value from this column when condition matches' },
+    { key: 'condition', label: 'Condition', kind: 'group', fields: [
+      { key: 'match_col', label: 'Match column', kind: 'text' },
+      { key: 'pattern', label: 'Regex pattern', kind: 'text' },
+    ] },
+  ]),
+  // constant_condition is intentionally a JSON field — its schema is a list of compare objects
+  // that would require a list-of-groups editor not yet built.
+  constant_condition: jsonFmt(4, '{ "compare": [...], "match_col": "col", "values": ["if_true", "if_false"] }'),
+
+  // ── Column control ───────────────────────────────────────────────────────
+  duplicate: txt('existing column name to copy'),
+  drop_duplicates: group([
+    { key: 'keep', label: 'Keep', kind: 'select', options: [
+      { value: 'first', label: 'first' }, { value: 'last', label: 'last' }, { value: 'false', label: 'none (false)' },
+    ] },
+  ]),
+
+  // ── Runtime / Environment ────────────────────────────────────────────────
+  override: txt('override_params key name (passed via --override_params)'),
+  get_running_environment: jsonFmt(3, '{ "prod": "PROD_VALUE", "uat": "UAT_VALUE" } — keyed by $INGEN_ENV'),
+  uuid: none,
+
+  // ── Encryption ───────────────────────────────────────────────────────────
+  encryption: none,
+  decryption: none,
+
+  // ── date-diff uses list format ────────────────────────────────────────────
+  'date-diff': jsonFmt(1, '[from_date_col, to_date_col, "%Y-%m-%d"]'),
+};
+
+/** @returns {Array} SchemaForm fields for the given formatter type (raw JSON fallback otherwise). */
+export function formatterSchema(type) {
+  return FORMATTER_FORMS[type] ?? jsonFmt(2, 'format value — see ingen/formatters/common_formatters.py');
+}

--- a/frontend/src/forms/schemas/outputSchemas.js
+++ b/frontend/src/forms/schemas/outputSchemas.js
@@ -1,0 +1,64 @@
+//  Output `props` descriptors for all writer types supported by the InGen backend.
+//  Derived from ingen/writer/ — InterfaceWriter (delimited_file, excel),
+//  JsonWriter (json_writer), and SplitFileWriter (splitted_file).
+//  output.type is the discriminator; these schemas cover the output.props body.
+
+const HEADER_FIELD = {
+  key: 'header', label: 'Header', kind: 'group', fields: [
+    { key: 'type', label: 'Type', kind: 'select', options: ['delimited_result_header', 'custom'] },
+  ],
+};
+
+export const OUTPUT_SCHEMAS = {
+  delimited_file: {
+    label: 'Delimited file',
+    schema: [
+      { key: 'path', label: 'Path', kind: 'text', placeholder: 'out/file_$date(%Y%m%d).csv' },
+      { key: 'delimiter', label: 'Delimiter', kind: 'text', placeholder: ',' },
+      { key: 'encoding', label: 'Encoding', kind: 'text', placeholder: 'utf-8' },
+      HEADER_FIELD,
+      { key: 'footer', label: 'Footer', kind: 'group', fields: [
+        { key: 'type', label: 'Type', kind: 'text', placeholder: 'custom' },
+      ] },
+    ],
+  },
+
+  excel: {
+    label: 'Excel',
+    schema: [
+      { key: 'path', label: 'Path', kind: 'text', placeholder: 'out/report_$date(%Y%m%d).xlsx' },
+      { key: 'sheet_name', label: 'Sheet name', kind: 'text', placeholder: 'Sheet1' },
+      HEADER_FIELD,
+    ],
+  },
+
+  json_writer: {
+    label: 'JSON writer',
+    schema: [
+      { key: 'destination', label: 'Destination', kind: 'select', options: ['file', 'api'], help: 'Where to write the JSON output' },
+      { key: 'destination_props', label: 'Destination props', kind: 'group', fields: [
+        { key: 'path', label: 'File path', kind: 'text', placeholder: 'out/file.json', help: 'Required when destination = file' },
+        { key: 'url', label: 'API URL', kind: 'text', help: 'Required when destination = api' },
+        { key: 'method', label: 'HTTP method', kind: 'select', options: ['POST', 'PUT', 'PATCH'] },
+        { key: 'headers', label: 'Headers', kind: 'json', rows: 2 },
+      ] },
+    ],
+  },
+
+  splitted_file: {
+    label: 'Splitted file',
+    schema: [
+      { key: 'path', label: 'Output directory', kind: 'text', placeholder: 'out/splits/', help: 'Files are written as <directory>/<split_col_value>.<ext>' },
+      { key: 'split_col', label: 'Split column', kind: 'text', help: 'Each unique value in this column produces a separate file' },
+      { key: 'delimiter', label: 'Delimiter', kind: 'text', placeholder: ',' },
+      { key: 'encoding', label: 'Encoding', kind: 'text', placeholder: 'utf-8' },
+      HEADER_FIELD,
+    ],
+  },
+};
+
+export const OUTPUT_TYPE_OPTIONS = Object.keys(OUTPUT_SCHEMAS);
+
+export function outputSchema(type) {
+  return OUTPUT_SCHEMAS[type]?.schema ?? [];
+}

--- a/frontend/src/forms/schemas/preProcessorSchemas.js
+++ b/frontend/src/forms/schemas/preProcessorSchemas.js
@@ -1,0 +1,126 @@
+//  Field descriptors for each pre-processor type (corrected against ingen/pre_processor source).
+//  `source`/`masking_source` selects resolve their options from ctx.sources (sibling source ids).
+
+const MERGE_TYPES = ['inner', 'left', 'right', 'outer'];
+
+export const PRE_PROCESSOR_SCHEMAS = {
+  merge: {
+    label: 'Merge',
+    description: 'Join two DataFrames on matching key columns, like a SQL JOIN. The base input is the left side; the wired source is the right.',
+    hint: 'Use when you need to combine data from two sources by a shared key (e.g. account id).',
+    yamlFields: ['source', 'left_key', 'right_key', 'merge_type'],
+    schema: [
+      { key: 'source', label: 'Right source', kind: 'select', optionsFrom: 'sources' },
+      { key: 'left_key', label: 'Left key', kind: 'text' },
+      { key: 'right_key', label: 'Right key', kind: 'text' },
+      { key: 'merge_type', label: 'Merge type', kind: 'select', options: MERGE_TYPES },
+    ],
+  },
+  outer_join: {
+    label: 'Outer join',
+    description: 'Full outer join between two DataFrames — keeps all rows from both sides, filling NaN for non-matching keys.',
+    hint: 'Use when you need every row from both sources, even if no match exists.',
+    yamlFields: ['source', 'left_key', 'right_key'],
+    schema: [
+      { key: 'source', label: 'Right source', kind: 'select', optionsFrom: 'sources' },
+      { key: 'left_key', label: 'Left key', kind: 'text' },
+      { key: 'right_key', label: 'Right key', kind: 'text' },
+    ],
+  },
+  union: {
+    label: 'Union',
+    description: 'Vertically concatenate (stack) multiple DataFrames. All sources must share compatible columns.',
+    hint: 'Use to combine rows from multiple sources with the same structure (e.g. daily files).',
+    yamlFields: ['source'],
+    schema: [{ key: 'source', label: 'Sources', kind: 'tags', help: 'source ids to concatenate' }],
+  },
+  aggregate: {
+    label: 'Aggregate',
+    description: 'Group rows by one or more columns and compute an aggregate (sum, count, min, max, mean) on another column.',
+    hint: 'Use to summarize data — e.g. total amount per account.',
+    yamlFields: ['groupby.cols', 'agg.operation', 'agg.col'],
+    schema: [
+      { key: 'groupby', label: 'Group by', kind: 'group', fields: [
+        { key: 'cols', label: 'Columns', kind: 'tags' },
+      ] },
+      { key: 'agg', label: 'Aggregation', kind: 'group', fields: [
+        { key: 'operation', label: 'Operation', kind: 'select', options: ['sum', 'count', 'min', 'max', 'mean'] },
+        { key: 'col', label: 'Column', kind: 'text' },
+      ] },
+    ],
+  },
+  mask: {
+    label: 'Mask',
+    description: 'Filter the base DataFrame by checking membership against a column in another source (masking source).',
+    hint: 'Use to keep only rows whose key appears in a reference/lookup table.',
+    yamlFields: ['on_col', 'masking_source', 'masking_col'],
+    schema: [
+      { key: 'on_col', label: 'On column', kind: 'text' },
+      { key: 'masking_source', label: 'Masking source', kind: 'select', optionsFrom: 'sources' },
+      { key: 'masking_col', label: 'Masking column', kind: 'text' },
+    ],
+  },
+  melt: {
+    label: 'Melt',
+    description: 'Unpivot (melt) wide-format columns into key-value rows. Turns multiple columns into a single "variable" + "value" pair.',
+    hint: 'Use when you have data spread across many columns that should be in rows (e.g. monthly columns → month + value).',
+    yamlFields: ['key_column', 'value_column', 'include_keys', 'source'],
+    schema: [
+      { key: 'key_column', label: 'Key column', kind: 'text' },
+      { key: 'value_column', label: 'Value column', kind: 'text' },
+      { key: 'include_keys', label: 'Include keys', kind: 'tags' },
+      { key: 'source', label: 'Source', kind: 'tags' },
+    ],
+  },
+  filter: {
+    label: 'Filter',
+    description: 'Keep rows matching conditions on column values. Conditions can be combined with AND / OR logic.',
+    hint: 'Use to remove unwanted rows — e.g. keep only status = "ACTIVE".',
+    yamlFields: ['operator', 'cols'],
+    schema: [
+      { key: 'operator', label: 'Operator', kind: 'select', options: ['and', 'or'] },
+      { key: 'cols', label: 'Conditions', kind: 'json', rows: 4, help: '[{ "col": "name", "val": ["x"] }]' },
+    ],
+  },
+  not_equals_filter: {
+    label: 'Not-equals filter',
+    description: 'Exclude rows where a column matches specific values. Optionally cross-references against another source.',
+    hint: 'Use to drop rows — e.g. exclude status = "CLOSED" or "CANCELLED".',
+    yamlFields: ['source', 'cols'],
+    schema: [
+      { key: 'source', label: 'Source (optional)', kind: 'select', optionsFrom: 'sources' },
+      { key: 'cols', label: 'Exclusions', kind: 'json', rows: 4, help: '[{ "col": "status", "val": ["CLOSED"] }]' },
+    ],
+  },
+  drop_duplicates: {
+    label: 'Drop duplicates',
+    description: 'Remove duplicate rows based on a subset of columns. Choose which occurrence to keep (first, last, or none).',
+    hint: 'Use to deduplicate — e.g. keep only the latest record per account.',
+    yamlFields: ['columns', 'keep'],
+    schema: [
+      { key: 'columns', label: 'Columns', kind: 'tags', help: 'subset; empty = all columns' },
+      { key: 'keep', label: 'Keep', kind: 'select', options: [
+        { value: 'first', label: 'first' }, { value: 'last', label: 'last' }, { value: 'false', label: 'none (false)' },
+      ] },
+    ],
+  },
+  json_array_expander: {
+    label: 'JSON array expander',
+    description: 'Expand a JSON array stored in a single column into multiple rows. Each element of the array becomes its own row.',
+    hint: 'Use when a column contains a JSON array string that needs flattening into rows.',
+    yamlFields: ['config.column', 'config.include_columns', 'config.exclude_columns'],
+    schema: [
+      { key: 'config', label: 'Config', kind: 'group', fields: [
+        { key: 'column', label: 'JSON column', kind: 'text' },
+        { key: 'include_columns', label: 'Include columns', kind: 'json', rows: 2 },
+        { key: 'exclude_columns', label: 'Exclude columns', kind: 'tags' },
+      ] },
+    ],
+  },
+};
+
+export const PRE_PROCESSOR_ORDER = Object.keys(PRE_PROCESSOR_SCHEMAS);
+
+export function preProcessorSchema(type) {
+  return PRE_PROCESSOR_SCHEMAS[type]?.schema ?? [];
+}

--- a/frontend/src/forms/schemas/sourceSchemas.js
+++ b/frontend/src/forms/schemas/sourceSchemas.js
@@ -1,0 +1,61 @@
+//  Field descriptors for each source type. Derived from ingen/data_source + docs/config_reference.
+//  `id` and `type` are handled by the SourcesEditor outside SchemaForm (id is the key; type the
+//  discriminator). These schemas cover the type-specific body.
+
+import { FILE_TYPES } from '../../models/constants.js';
+
+// Trimmed to the two essentials. Niche knobs (delimiter, encoding, sheet_name, skip rows, dtype,
+// col_specification, etc.) were removed from the builder — they're still settable via raw YAML.
+const FILE = [
+  { key: 'file_type', label: 'File type', kind: 'select', options: Object.values(FILE_TYPES), required: true },
+  { key: 'file_path', label: 'File path', kind: 'text', placeholder: 'data/file_$date(%Y%m%d).csv', required: true },
+];
+
+const MYSQL = [
+  { key: 'database', label: 'Database name', kind: 'text', help: 'Matches the database key in your properties file', required: true },
+  { key: 'query', label: 'SQL query', kind: 'textarea', rows: 4, placeholder: 'SELECT col1, col2 FROM table WHERE date = {date}', required: true },
+];
+
+// Ordered by how often you reach for it: request → response shaping → retries.
+// Niche knobs are gated behind the field that gives them meaning (visibleIf), so the Advanced
+// panel starts short and grows only as you opt in.
+const API = [
+  { key: 'url', label: 'Base URL', kind: 'text', required: true },
+  { key: 'method', label: 'Method', kind: 'select', options: ['GET', 'POST', 'PUT', 'DELETE'], required: true },
+  // — request —
+  { key: 'headers', label: 'Headers', kind: 'json', rows: 3 },
+  { key: 'request_body', label: 'Request body', kind: 'textarea', rows: 3, visibleIf: (v) => ['POST', 'PUT', 'PATCH'].includes(v.method) },
+  { key: 'auth', label: 'Auth', kind: 'group', fields: [
+    { key: 'type', label: 'Type', kind: 'text', placeholder: 'BasicAuth' },
+    { key: 'username', label: 'Username/token', kind: 'text' },
+    { key: 'pwd', label: 'Password/token', kind: 'text' },
+  ] },
+  { key: 'url_params', label: 'URL params', kind: 'json', rows: 3 },
+  // — response shaping —
+  { key: 'data_node', label: 'data_node', kind: 'tags' },
+  { key: 'data_key', label: 'data_key', kind: 'tags' },
+  { key: 'success_criteria', label: 'Success criteria', kind: 'text' },
+  { key: 'criteria_option', label: 'Criteria option', kind: 'json', rows: 2, visibleIf: (v) => !!v.success_criteria },
+  // — retries (interval only matters once you retry) —
+  { key: 'retries', label: 'Retries', kind: 'number' },
+  { key: 'interval', label: 'Interval (s)', kind: 'number', visibleIf: (v) => v.retries != null },
+];
+
+// json has no body fields (payload supplied at runtime).
+const NONE = [];
+
+const SCHEMAS = { file: FILE, mysql: MYSQL, api: API, json: NONE };
+
+export function sourceSchema(type) {
+  return SCHEMAS[type] ?? [];
+}
+
+/** Fields flagged `required` — shown up-front in the source loader. */
+export function requiredSourceFields(type) {
+  return (SCHEMAS[type] ?? []).filter((f) => f.required);
+}
+
+/** Everything else — collapsed under "Advanced". */
+export function advancedSourceFields(type) {
+  return (SCHEMAS[type] ?? []).filter((f) => !f.required);
+}

--- a/frontend/src/forms/schemas/validationSchemas.js
+++ b/frontend/src/forms/schemas/validationSchemas.js
@@ -1,0 +1,30 @@
+//  Validation expectation metadata. Formatted-frame validations are stored PER COLUMN under
+//  columns[i].validations[] as { type, severity, args } — confirmed against ingen/validation/
+//  validations.py (it reads column.get('validations')). args are expectation-specific.
+
+import { VALIDATION_TYPES, VALIDATION_SEVERITIES } from '../../models/constants.js';
+
+/** Per-expectation arg hint (shown in the args JSON editor). Empty string ⇒ no args. */
+export const VALIDATION_ARG_HINTS = {
+  expect_column_values_to_not_be_null: '',
+  expect_column_values_to_be_unique: '',
+  expect_column_values_to_match_regex_list: '[["^[0-9]+$"], "any"]',
+  expect_column_values_to_match_strftime_format: '["%Y-%m-%d"]',
+  expect_column_values_to_be_between: '[10, 20]',
+  expect_column_value_lengths_to_equal: '[8]',
+  expect_column_to_contain_values: '[["XUSD0000", "ABC1234F"]]',
+  expect_column_values_to_be_of_type: '["float"]',
+  expect_column_values_to_be_present_in: '[["src", "col"]]',
+  expect_column_to_be_present_in: '[["COL_2", "cusip"]]',
+};
+
+export const ALL_EXPECTATIONS = [...VALIDATION_TYPES.BUILTIN, ...VALIDATION_TYPES.CUSTOM];
+
+export const SEVERITY_OPTIONS = Object.values(VALIDATION_SEVERITIES);
+
+/** Human note on what each severity does post-failure (from the backend severity handling). */
+export const SEVERITY_ACTION = {
+  blocker: 'aborts the interface',
+  critical: 'drops failing rows',
+  warning: 'reports only',
+};

--- a/frontend/src/hooks/useDocTitle.js
+++ b/frontend/src/hooks/useDocTitle.js
@@ -1,0 +1,13 @@
+//  useDocTitle — sets document.title with an optional segment and the app suffix.
+//  Example: useDocTitle('interface_1', 'My Pipeline') → "interface_1 — My Pipeline — InGen Studio"
+
+import { useEffect } from 'react';
+
+const SUFFIX = 'InGen Studio';
+
+export function useDocTitle(...segments) {
+  useEffect(() => {
+    const parts = segments.filter(Boolean);
+    document.title = parts.length > 0 ? `${parts.join(' — ')} — ${SUFFIX}` : SUFFIX;
+  }, [segments.join('|')]);   // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/frontend/src/hooks/useSourceActions.js
+++ b/frontend/src/hooks/useSourceActions.js
@@ -1,0 +1,59 @@
+'use client';
+
+//  useSourceActions — the "what should happen to this source?" dialog behaviour.
+//
+//  When a source is picked from the registry the user is asked whether to start a NEW interface
+//  from it or MERGE it into the current one. Three surfaces offer that choice (the sources tab,
+//  the graph canvas and the nav rail), so the state and both handlers live here rather than being
+//  copied into each.
+
+import { useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { useConfig } from '../state/ConfigContext.jsx';
+import { upsertInterface, createEmptyInterface } from '../models/configModel.js';
+
+/**
+ * @param {string} interfaceName  interface the merge action applies to
+ * @param {{ onMerged?: () => void }} [opts]  onMerged fires after a successful merge (e.g. so the
+ *        graph can recompute its layout)
+ */
+export function useSourceActions(interfaceName, { onMerged } = {}) {
+  const { model, updateModel, updateInterface } = useConfig();
+  const router = useRouter();
+  const { configId } = useParams() || {};
+  const [pendingSourceAction, setPendingSourceAction] = useState(null); // { sid } | null
+
+  const handleNewInterface = () => {
+    if (!pendingSourceAction) return;
+    const { sid } = pendingSourceAction;
+    const newName = `${sid}_pipeline`;
+    const finalName = model.interfacesByName[newName] ? `${newName}_${Date.now()}` : newName;
+    updateModel((m) =>
+      upsertInterface(m, finalName, { ...createEmptyInterface(), sources: [sid] }),
+    );
+    setPendingSourceAction(null);
+    if (configId) {
+      router.push(`/configs/${configId}/interfaces/${encodeURIComponent(finalName)}`);
+    }
+  };
+
+  const handleMergeSource = () => {
+    if (!pendingSourceAction) return;
+    const { sid } = pendingSourceAction;
+    updateInterface(interfaceName, (it) => {
+      const cur = it.sources ?? [];
+      return {
+        ...it,
+        sources: cur.includes(sid) ? cur : [...cur, sid],
+        pre_processing: [
+          ...(it.pre_processing ?? []),
+          { type: 'merge', source: sid, merge_type: 'inner', left_key: '', right_key: '' },
+        ],
+      };
+    });
+    onMerged?.();
+    setPendingSourceAction(null);
+  };
+
+  return { pendingSourceAction, setPendingSourceAction, handleNewInterface, handleMergeSource };
+}

--- a/frontend/src/hooks/useWorkspaceShortcuts.js
+++ b/frontend/src/hooks/useWorkspaceShortcuts.js
@@ -1,0 +1,40 @@
+//  useWorkspaceShortcuts — global keyboard shortcuts active while in the workspace.
+//  Ctrl+S  → flush the debounced autosave immediately
+//  Ctrl+Z  → undo
+//  Ctrl+Y / Ctrl+Shift+Z → redo
+//
+//  Does NOT intercept events originating from <input>, <textarea>, or <select> so typing
+//  in form fields is never blocked.
+
+import { useEffect } from 'react';
+
+function isFormElement(el) {
+  return el && ['INPUT', 'TEXTAREA', 'SELECT'].includes(el.tagName);
+}
+
+/**
+ * @param {{ onSave?: () => void, onUndo?: () => void, onRedo?: () => void }} handlers
+ */
+export function useWorkspaceShortcuts({ onSave, onUndo, onRedo } = {}) {
+  useEffect(() => {
+    const handler = (e) => {
+      if (isFormElement(document.activeElement)) return;
+      const ctrl = e.ctrlKey || e.metaKey;
+      if (!ctrl) return;
+
+      if (e.key === 's') {
+        e.preventDefault();
+        onSave?.();
+      } else if (e.key === 'z' && !e.shiftKey) {
+        e.preventDefault();
+        onUndo?.();
+      } else if (e.key === 'y' || (e.key === 'z' && e.shiftKey)) {
+        e.preventDefault();
+        onRedo?.();
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onSave, onUndo, onRedo]);
+}

--- a/frontend/src/lib/columnStore.js
+++ b/frontend/src/lib/columnStore.js
@@ -1,0 +1,21 @@
+//  Per-source column cache (from file uploads). Kept OUT of the config model so it never leaks into
+//  the serialized YAML — the serializer dumps source objects verbatim. Uses localStorage so column
+//  names survive tab close and reload (previously sessionStorage caused silent autocomplete loss).
+
+const KEY = (sid) => `ingen:cols:${sid}`;
+
+export function setColumns(sourceId, columns) {
+  try { localStorage.setItem(KEY(sourceId), JSON.stringify(columns || [])); } catch { /* ignore */ }
+}
+
+export function getColumns(sourceId) {
+  try { return JSON.parse(localStorage.getItem(KEY(sourceId))) || []; } catch { return []; }
+}
+
+/** Union of columns across a list of source ids (deduped, order-preserving). */
+export function columnsForSources(sourceIds = []) {
+  const seen = new Set();
+  const out = [];
+  for (const sid of sourceIds) for (const c of getColumns(sid)) if (!seen.has(c)) { seen.add(c); out.push(c); }
+  return out;
+}

--- a/frontend/src/services/catalogService.js
+++ b/frontend/src/services/catalogService.js
@@ -1,0 +1,25 @@
+//  InGen Studio — CatalogService interface
+//
+//  Serves the component palettes (source types, pre/post-processors, formatters, validations,
+//  writers, interpolators). These are static and derived from the backend registries, so the
+//  catalog adapter returns them straight from src/models/constants.js in both mock and http mode.
+
+/**
+ * @typedef {Object} Catalog
+ * @property {string[]} sourceTypes
+ * @property {string[]} fileTypes
+ * @property {string[]} preProcessors
+ * @property {string[]} postProcessors
+ * @property {string[]} formatters
+ * @property {{ builtin: string[], custom: string[] }} validations
+ * @property {string[]} validationSeverities
+ * @property {string[]} outputTypes
+ * @property {{ static: string[], runtime: string[] }} interpolators
+ */
+
+const NOT_IMPLEMENTED = 'CatalogService method not implemented by adapter';
+
+export class CatalogService {
+  /** @returns {Promise<Catalog>} the full catalog in one call. */
+  async getCatalog() { throw new Error(NOT_IMPLEMENTED); }
+}

--- a/frontend/src/services/chatHistoryService.js
+++ b/frontend/src/services/chatHistoryService.js
@@ -1,0 +1,101 @@
+//  InGen Studio — Chat History Service
+//
+//  Persists chat conversations per-interface in localStorage. Each interface can have multiple
+//  sessions; the active session is always the most recent. Provides CRUD for the sidebar
+//  history panel in Chat mode.
+
+import { makeId } from '../utils/id.js';
+
+const STORAGE_KEY = 'ingen_chat_history';
+
+function readAll() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(data) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+/**
+ * Get all sessions for an interface, sorted newest-first.
+ * @param {string} interfaceName
+ * @returns {{ id: string, messages: object[], createdAt: string, preview: string }[]}
+ */
+export function getSessions(interfaceName) {
+  const all = readAll();
+  const sessions = all[interfaceName] ?? [];
+  return sessions.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+}
+
+/**
+ * Get the most recent (active) session for an interface, or null.
+ * @param {string} interfaceName
+ * @returns {{ id: string, messages: object[], createdAt: string, preview: string } | null}
+ */
+export function getActiveSession(interfaceName) {
+  const sessions = getSessions(interfaceName);
+  return sessions.length > 0 ? sessions[0] : null;
+}
+
+/**
+ * Save or update a session. If the session id already exists it is replaced;
+ * otherwise it is appended.
+ * @param {string} interfaceName
+ * @param {{ id: string, messages: object[], createdAt: string }} session
+ */
+export function saveSession(interfaceName, session) {
+  const all = readAll();
+  const sessions = all[interfaceName] ?? [];
+  const idx = sessions.findIndex((s) => s.id === session.id);
+  const preview = session.messages
+    .filter((m) => m.sender === 'user')
+    .map((m) => m.text)
+    .slice(-1)[0] || 'Empty conversation';
+
+  // Preserve the original creation time on update. Autosave passes a fresh timestamp on every
+  // keystroke-triggered save, and getSessions() sorts on createdAt — letting it drift would
+  // reshuffle the sidebar while the user types.
+  const entry = {
+    ...session,
+    createdAt: idx >= 0 ? (sessions[idx].createdAt ?? session.createdAt) : session.createdAt,
+    preview: preview.slice(0, 80),
+  };
+
+  if (idx >= 0) {
+    sessions[idx] = entry;
+  } else {
+    sessions.push(entry);
+  }
+
+  all[interfaceName] = sessions;
+  writeAll(all);
+}
+
+/**
+ * Delete a specific session.
+ * @param {string} interfaceName
+ * @param {string} sessionId
+ */
+export function deleteSession(interfaceName, sessionId) {
+  const all = readAll();
+  all[interfaceName] = (all[interfaceName] ?? []).filter((s) => s.id !== sessionId);
+  writeAll(all);
+}
+
+/**
+ * Create a new empty session and return it.
+ * @returns {{ id: string, messages: object[], createdAt: string, preview: string }}
+ */
+export function createSession() {
+  const session = {
+    id: makeId('chat'),
+    messages: [],
+    createdAt: new Date().toISOString(),
+    preview: 'New conversation',
+  };
+  return session;
+}

--- a/frontend/src/services/configService.js
+++ b/frontend/src/services/configService.js
@@ -1,0 +1,49 @@
+//  InGen Studio — ConfigService interface
+//
+//  The adapter-agnostic contract for persisting and translating config documents. Both the
+//  localStorage-backed MockConfigAdapter and the HttpConfigAdapter that calls the FastAPI wrapper
+//  satisfy the SAME signatures. UI code depends only on this interface, so swapping adapters
+//  touches nothing in the components.
+//
+//  Pattern: an abstract base class whose methods throw until an adapter overrides them. This gives
+//  us a single place to document the contract and a runtime guard against unimplemented methods.
+
+/** @typedef {import('../models/types.js').ConfigModel} ConfigModel */
+/** @typedef {import('../models/types.js').ConfigIssue} ConfigIssue */
+
+/**
+ * Lightweight listing entry (no full body) for the configs landing page.
+ * @typedef {Object} ConfigSummary
+ * @property {string} id
+ * @property {string} name
+ * @property {string} updatedAt
+ * @property {number} interfaceCount
+ */
+
+const NOT_IMPLEMENTED = 'ConfigService method not implemented by adapter';
+
+export class ConfigService {
+  /** @returns {Promise<ConfigSummary[]>} */
+  async list() { throw new Error(NOT_IMPLEMENTED); }
+
+  /** @param {string} id @returns {Promise<ConfigModel>} */
+  async get(id) { void id; throw new Error(NOT_IMPLEMENTED); }
+
+  /** @param {ConfigModel} model @returns {Promise<ConfigModel>} */
+  async create(model) { void model; throw new Error(NOT_IMPLEMENTED); }
+
+  /** @param {ConfigModel} model @returns {Promise<ConfigModel>} */
+  async update(model) { void model; throw new Error(NOT_IMPLEMENTED); }
+
+  /** @param {string} id @returns {Promise<void>} */
+  async remove(id) { void id; throw new Error(NOT_IMPLEMENTED); }
+
+  /** Schema/cross-reference validation without running the pipeline. @param {ConfigModel} model @returns {Promise<ConfigIssue[]>} */
+  async validate(model) { void model; throw new Error(NOT_IMPLEMENTED); }
+
+  /** Parse pasted YAML into a model. @param {string} yamlText @returns {Promise<ConfigModel>} */
+  async importYaml(yamlText) { void yamlText; throw new Error(NOT_IMPLEMENTED); }
+
+  /** Serialize a model to YAML text. @param {ConfigModel} model @returns {Promise<string>} */
+  async exportYaml(model) { void model; throw new Error(NOT_IMPLEMENTED); }
+}

--- a/frontend/src/services/fileService.js
+++ b/frontend/src/services/fileService.js
@@ -1,0 +1,31 @@
+//  inFlow/inChat — file upload service. Talks directly to the local FastAPI wrapper (local-only
+//  app, no adapter indirection needed for this). Returns { file_path, columns, preview, cached }.
+
+const API = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+
+export async function uploadFile(file) {
+  const body = new FormData();
+  body.append('file', file);
+  const res = await fetch(`${API}/api/files/upload`, { method: 'POST', body });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({}));
+    throw new Error(detail.detail || `Upload failed (${res.status})`);
+  }
+  return res.json();
+}
+
+//  Read a configured source's column names (first row) via the backend — works for file paths,
+//  MySQL queries, and API endpoints. Returns string[]. Throws with the backend's message on failure.
+export async function fetchSourceColumns(source) {
+  const res = await fetch(`${API}/api/sources/columns`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ source }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({}));
+    throw new Error(detail.detail || `Couldn't read columns (${res.status})`);
+  }
+  const { columns } = await res.json();
+  return columns || [];
+}

--- a/frontend/src/services/historyService.js
+++ b/frontend/src/services/historyService.js
@@ -1,0 +1,22 @@
+//  InGen Studio — HistoryService interface
+//
+//  Persists completed RunRecords for the Execution History view. The mock adapter uses
+//  localStorage; the HTTP adapter reads the wrapper's runs endpoint. Same signatures.
+
+/** @typedef {import('./runService.js').RunRecord} RunRecord */
+
+const NOT_IMPLEMENTED = 'HistoryService method not implemented by adapter';
+
+export class HistoryService {
+  /** @param {string} configId @returns {Promise<RunRecord[]>} newest first */
+  async list(configId) { void configId; throw new Error(NOT_IMPLEMENTED); }
+
+  /** @param {string} runId @returns {Promise<RunRecord|null>} */
+  async get(runId) { void runId; throw new Error(NOT_IMPLEMENTED); }
+
+  /** @param {RunRecord} record @returns {Promise<void>} */
+  async add(record) { void record; throw new Error(NOT_IMPLEMENTED); }
+
+  /** @param {string} configId @returns {Promise<void>} */
+  async clear(configId) { void configId; throw new Error(NOT_IMPLEMENTED); }
+}

--- a/frontend/src/services/index.js
+++ b/frontend/src/services/index.js
@@ -1,0 +1,43 @@
+//  InGen Studio — services barrel + locator
+//
+//  Components import `getServices()` and never touch adapters directly. The active backend mode is
+//  read once from the Next env (NEXT_PUBLIC_ADAPTER_MODE), defaulting to mock. This is the seam that
+//  makes the mock→FastAPI swap a one-line config change.
+
+import { ADAPTER_MODE } from '../models/constants.js';
+import { buildServices } from '../adapters/index.js';
+
+export { ConfigService } from './configService.js';
+export { CatalogService } from './catalogService.js';
+export { ValidationService } from './validationService.js';
+export { RunService } from './runService.js';
+export { HistoryService } from './historyService.js';
+
+/** Resolve the configured adapter mode from the build env, defaulting to mock. */
+function resolveMode() {
+  // Next inlines NEXT_PUBLIC_* at build time for client bundles; process.env also works in plain
+  // Node test runs, so no guard is needed.
+  return process.env.NEXT_PUBLIC_ADAPTER_MODE ?? ADAPTER_MODE.MOCK;
+}
+
+/** The active backend mode (one of ADAPTER_MODE.*). Lets the UI label real vs. simulated runs. */
+export function getAdapterMode() {
+  return resolveMode();
+}
+
+/** @type {import('../adapters/index.js').ServiceSet | null} */
+let _services = null;
+
+/**
+ * Lazily construct and memoize the service set for the current mode.
+ * @returns {import('../adapters/index.js').ServiceSet}
+ */
+export function getServices() {
+  if (!_services) _services = buildServices(resolveMode());
+  return _services;
+}
+
+/** Test/util hook: force a specific service set (e.g. inject fakes) or reset memoization. */
+export function setServices(services) {
+  _services = services;
+}

--- a/frontend/src/services/runService.js
+++ b/frontend/src/services/runService.js
@@ -1,0 +1,51 @@
+//  InGen Studio — RunService interface
+//
+//  Executes a pipeline. `simulate` streams events (logs + stage transitions) through a handler and
+//  resolves with the final RunRecord. The mock adapter fabricates that stream locally; the HTTP
+//  adapter POSTs to the wrapper's /api/runs and replays the returned record through the same
+//  handler. Both implement this signature, so the Run Console never changes.
+
+/**
+ * @typedef {Object} RunEvent
+ * @property {'log'|'stage'} type
+ * @property {string} ts                 ISO timestamp
+ * @property {string} [interface]
+ * @property {string} [stage]            read | pre_process | format | validate | write
+ * @property {'info'|'warn'|'error'} [level]   for log events
+ * @property {string} [message]          for log events
+ * @property {'running'|'ok'|'warning'|'failed'|'skipped'} [status]  for stage events
+ */
+
+/**
+ * @typedef {Object} RunStage
+ * @property {string} interface
+ * @property {string} stage
+ * @property {'ok'|'warning'|'failed'|'skipped'} status
+ */
+
+/**
+ * @typedef {Object} RunRecord
+ * @property {string} runId
+ * @property {string} configId
+ * @property {string} configName
+ * @property {'success'|'partial'|'failed'} status
+ * @property {string} startedAt
+ * @property {string} finishedAt
+ * @property {number} durationMs
+ * @property {RunStage[]} stages
+ * @property {RunEvent[]} logs
+ * @property {import('./validationService.js').ValidationReport} validation
+ * @property {Object} overrides           runtime overrides used (run_date, interfaces, params…)
+ */
+
+const NOT_IMPLEMENTED = 'RunService method not implemented by adapter';
+
+export class RunService {
+  /**
+   * @param {import('../models/types.js').ConfigModel} model
+   * @param {Object} overrides
+   * @param {{ onEvent?: (e: RunEvent) => void, isCancelled?: () => boolean }} [handlers]
+   * @returns {Promise<RunRecord>}
+   */
+  async simulate(model, overrides, handlers) { void model; void overrides; void handlers; throw new Error(NOT_IMPLEMENTED); }
+}

--- a/frontend/src/services/validationService.js
+++ b/frontend/src/services/validationService.js
@@ -1,0 +1,32 @@
+//  InGen Studio — ValidationService interface
+//
+//  Produces validation results for a configured pipeline WITHOUT executing it. The mock derives
+//  realistic pass/fail/warn outcomes from the column validations actually configured in the model;
+//  the HTTP adapter returns real great_expectations results from the backend. Same shape.
+
+/**
+ * @typedef {Object} ValidationResult
+ * @property {string} interface
+ * @property {string} column
+ * @property {string} expectation
+ * @property {'blocker'|'critical'|'warning'} severity
+ * @property {'passed'|'failed'|'warning'} status
+ * @property {number} unexpectedCount
+ */
+
+/**
+ * @typedef {Object} ValidationReport
+ * @property {ValidationResult[]} results
+ * @property {{ passed: number, failed: number, warning: number, total: number }} summary
+ */
+
+const NOT_IMPLEMENTED = 'ValidationService method not implemented by adapter';
+
+export class ValidationService {
+  /**
+   * @param {import('../models/types.js').ConfigModel} model
+   * @param {string[]} [interfaceNames] subset; defaults to all
+   * @returns {Promise<ValidationReport>}
+   */
+  async evaluate(model, interfaceNames) { void model; void interfaceNames; throw new Error(NOT_IMPLEMENTED); }
+}

--- a/frontend/src/state/CatalogContext.jsx
+++ b/frontend/src/state/CatalogContext.jsx
@@ -1,0 +1,34 @@
+//  InGen Studio — CatalogContext
+//
+//  Loads the static catalog once (via CatalogService) and shares it. The catalog drives palettes
+//  and dropdowns — e.g. labelling the available output types and populating the schema-driven
+//  form option lists.
+
+import { createContext, useContext, useEffect, useState } from 'react';
+import { getServices } from '../services/index.js';
+
+/** @type {import('react').Context<{ catalog: any, loading: boolean }>} */
+const CatalogContext = createContext({ catalog: null, loading: true });
+
+export function CatalogProvider({ children }) {
+  const [catalog, setCatalog] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    getServices()
+      .catalog.getCatalog()
+      .then((c) => {
+        if (!alive) return;
+        setCatalog(c);
+        setLoading(false);
+      });
+    return () => { alive = false; };
+  }, []);
+
+  return <CatalogContext.Provider value={{ catalog, loading }}>{children}</CatalogContext.Provider>;
+}
+
+export function useCatalog() {
+  return useContext(CatalogContext);
+}

--- a/frontend/src/state/ChatSessionContext.jsx
+++ b/frontend/src/state/ChatSessionContext.jsx
@@ -1,0 +1,40 @@
+//  InGen Studio — ChatSessionContext
+//
+//  Bridges the Chat-mode sidebar (NavRail, which lists every saved conversation) and the chat
+//  editor (InterfaceChatEditor, which owns the live conversation). They live in different branches
+//  of the tree, so this shared state is how the sidebar drives the editor:
+//
+//    - The editor reports its current session id via `setActiveSessionId` so the sidebar can
+//      highlight the open conversation.
+//    - The sidebar issues a one-shot `command` ({ kind: 'new' } | { kind: 'load', ... }); the
+//      editor picks it up and calls `consumeCommand()` so it fires exactly once.
+
+import { createContext, useContext, useState, useCallback, useMemo } from 'react';
+
+const ChatSessionContext = createContext(null);
+
+export function ChatSessionProvider({ children }) {
+  const [activeSessionId, setActiveSessionId] = useState(null);
+  const [command, setCommand] = useState(null);
+
+  const requestNew = useCallback(() => setCommand({ kind: 'new', nonce: Date.now() }), []);
+  const requestLoad = useCallback(
+    (interfaceName, sessionId) =>
+      setCommand({ kind: 'load', interfaceName, sessionId, nonce: Date.now() }),
+    [],
+  );
+  const consumeCommand = useCallback(() => setCommand(null), []);
+
+  const value = useMemo(
+    () => ({ activeSessionId, setActiveSessionId, command, requestNew, requestLoad, consumeCommand }),
+    [activeSessionId, command, requestNew, requestLoad, consumeCommand],
+  );
+
+  return <ChatSessionContext.Provider value={value}>{children}</ChatSessionContext.Provider>;
+}
+
+export function useChatSession() {
+  const ctx = useContext(ChatSessionContext);
+  if (!ctx) throw new Error('useChatSession must be used within a ChatSessionProvider');
+  return ctx;
+}

--- a/frontend/src/state/ConfigContext.jsx
+++ b/frontend/src/state/ConfigContext.jsx
@@ -1,0 +1,165 @@
+//  InGen Studio — ConfigContext (the document store)
+//
+//  Holds the single ConfigModel under edit and is the bridge between the UI and the data layer.
+//  Responsibilities:
+//    - load the model by id from ConfigService (mock adapter → localStorage)
+//    - expose pure updaters that replace the model immutably
+//    - derive the live YAML (real serializer) and validation issues with useMemo
+//    - autosave (debounced) back through ConfigService → real persistence + Saved/Unsaved/Saving pill
+//
+//  This is the ONLY place that calls the service for config I/O, so switching between the mock and
+//  HTTP adapters changes nothing here or in any consumer.
+
+import { createContext, useContext, useEffect, useMemo, useRef, useState, useCallback } from 'react';
+
+import { getServices } from '../services/index.js';
+import { modelToYaml } from '../serializers/index.js';
+import { validateConfigModel, upsertInterface } from '../models/configModel.js';
+import { useModelHistory } from './useModelHistory.js';
+
+/**
+ * @typedef {Object} ConfigContextValue
+ * @property {import('../models/types.js').ConfigModel | null} model
+ * @property {string} status            'loading' | 'saved' | 'dirty' | 'saving' | 'error'
+ * @property {string} yaml              live-serialized YAML of the current model
+ * @property {import('../models/types.js').ConfigIssue[]} issues
+ * @property {(updater: (m: any) => any) => void} updateModel
+ * @property {(name: string, updater: (iface: any) => any) => void} updateInterface
+ * @property {() => void} undo
+ * @property {() => void} redo
+ * @property {boolean} canUndo
+ * @property {boolean} canRedo
+ */
+
+const ConfigContext = createContext(/** @type {ConfigContextValue} */ (null));
+
+const SAVE_DEBOUNCE_MS = 600;
+
+export function ConfigProvider({ configId, children }) {
+  const [model, setModel] = useState(null);
+  const [status, setStatus] = useState('loading');
+  const saveTimer = useRef(null);
+  const history = useModelHistory();
+  // The last model reference that has been persisted. Drives the autosave decision (model !==
+  // savedRef → there are unsaved edits) WITHOUT coupling it to `status`, which is what caused the
+  // earlier data-loss race (a save resolving could cancel a pending save of a newer edit).
+  const savedRef = useRef(null);
+  // Always-current model reference, readable from inside an in-flight save's async closure so we
+  // can tell whether a newer edit landed while we were saving.
+  const modelRef = useRef(null);
+
+  // Load the config. The provider is mounted with key={configId} (see ConfigWorkspace), so a
+  // different config remounts this with fresh 'loading'/null state — no synchronous reset needed.
+  useEffect(() => {
+    let alive = true;
+    getServices()
+      .config.get(configId)
+      .then((m) => {
+        if (!alive) return;
+        savedRef.current = m;
+        modelRef.current = m;
+        setModel(m);
+        setStatus('saved');
+      })
+      .catch(() => { if (alive) setStatus('error'); });
+    return () => { alive = false; };
+  }, [configId]);
+
+  // Keep modelRef in lockstep with the rendered model.
+  useEffect(() => { modelRef.current = model; }, [model]);
+
+  //  Apply an immutable update and mark dirty. Pushes a history snapshot BEFORE the mutation.
+  //
+  //  pushHistory is deliberately NOT called inside a setModel updater: React invokes updaters twice
+  //  under StrictMode, which would record two snapshots per edit and make undo need two presses.
+  //  modelRef is advanced synchronously here so several updateModel calls in one tick still chain
+  //  off each other's result rather than a stale render value.
+  const updateModel = useCallback((updater) => {
+    const prev = modelRef.current;
+    if (!prev) return;
+    history.pushHistory(prev);
+    const next = updater(prev);
+    modelRef.current = next;
+    setModel(next);
+    setStatus('dirty');
+  }, [history]);
+
+  // Convenience for the common case of editing one interface.
+  const updateInterface = useCallback((name, updater) => {
+    updateModel((m) => {
+      const current = m.interfacesByName[name];
+      if (!current) return m;
+      return upsertInterface(m, name, updater(current));
+    });
+  }, [updateModel]);
+
+  // Debounced autosave (real persistence). Triggered by the MODEL changing away from the last
+  // persisted reference — never by `status`. Each edit reschedules the debounce; an in-flight save
+  // only flips the pill to 'saved' if no newer edit arrived meanwhile (otherwise the newer edit's
+  // own effect run keeps the save chain going), so the latest edit is never silently dropped.
+  useEffect(() => {
+    if (!model || model === savedRef.current) return;
+    clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(async () => {
+      const toSave = model;
+      setStatus('saving');
+      try {
+        await getServices().config.update(toSave);
+        savedRef.current = toSave;
+        // Only declare 'saved' if this is still the newest model; otherwise a pending save covers it.
+        if (modelRef.current === toSave) setStatus('saved');
+      } catch {
+        setStatus('error');
+      }
+    }, SAVE_DEBOUNCE_MS);
+    return () => clearTimeout(saveTimer.current);
+  }, [model]);
+
+  // Derived, recomputed only when the model changes.
+  const yaml = useMemo(() => (model ? modelToYaml(model) : ''), [model]);
+  const issues = useMemo(() => (model ? validateConfigModel(model) : []), [model]);
+
+  // modelRef is advanced here too, so an edit made immediately after an undo branches from the
+  // restored model rather than the one it replaced.
+  const undo = useCallback(() => {
+    history.undo(modelRef.current, (m) => { modelRef.current = m; setModel(m); setStatus('dirty'); });
+  }, [history]);
+
+  const redo = useCallback(() => {
+    history.redo(modelRef.current, (m) => { modelRef.current = m; setModel(m); setStatus('dirty'); });
+  }, [history]);
+
+  // Flush the pending autosave immediately (e.g. triggered by Ctrl+S).
+  const saveNow = useCallback(async () => {
+    const m = modelRef.current;
+    if (!m || m === savedRef.current) return;
+    clearTimeout(saveTimer.current);
+    setStatus('saving');
+    try {
+      await getServices().config.update(m);
+      savedRef.current = m;
+      if (modelRef.current === m) setStatus('saved');
+    } catch {
+      setStatus('error');
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      model, status, yaml, issues,
+      updateModel, updateInterface,
+      undo, redo, saveNow,
+      canUndo: history.canUndo,
+      canRedo: history.canRedo,
+    }),
+    [model, status, yaml, issues, updateModel, updateInterface, undo, redo, saveNow, history.canUndo, history.canRedo],
+  );
+
+  return <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>;
+}
+
+export function useConfig() {
+  const ctx = useContext(ConfigContext);
+  if (!ctx) throw new Error('useConfig must be used within a ConfigProvider');
+  return ctx;
+}

--- a/frontend/src/state/GraphSelectionContext.jsx
+++ b/frontend/src/state/GraphSelectionContext.jsx
@@ -1,0 +1,21 @@
+//  InGen Studio — GraphSelectionContext
+//
+//  Bridges the inFlow sidebar (NavRail) and the canvas (InterfaceGraphEditor), which live in
+//  different branches of the tree. The sidebar adds a node, then sets the selection here so the
+//  canvas opens that node's config drawer. Mirrors ChatSessionContext.
+
+import { createContext, useContext, useState, useMemo } from 'react';
+
+const GraphSelectionContext = createContext(null);
+
+export function GraphSelectionProvider({ children }) {
+  const [selectedNodeId, setSelectedNodeId] = useState(null);
+  const value = useMemo(() => ({ selectedNodeId, setSelectedNodeId }), [selectedNodeId]);
+  return <GraphSelectionContext.Provider value={value}>{children}</GraphSelectionContext.Provider>;
+}
+
+export function useGraphSelection() {
+  const ctx = useContext(GraphSelectionContext);
+  if (!ctx) throw new Error('useGraphSelection must be used within a GraphSelectionProvider');
+  return ctx;
+}

--- a/frontend/src/state/RunContext.jsx
+++ b/frontend/src/state/RunContext.jsx
@@ -1,0 +1,80 @@
+//  InGen Studio — RunContext
+//
+//  Scoped to the Run Console route. Owns the lifecycle of a (mock) execution so the console's child
+//  panels — stage timeline, log stream, validation results — share one source of truth without prop
+//  drilling. Calls RunService.simulate (streaming events) and, on completion, persists the record via
+//  HistoryService. Reads the model from ConfigContext, so it stays in sync with the edited config.
+
+import { createContext, useContext, useState, useRef, useCallback } from 'react';
+
+import { getServices } from '../services/index.js';
+import { makeId } from '../utils/id.js';
+import { useConfig } from './ConfigContext.jsx';
+
+const RunContext = createContext(null);
+
+export function RunProvider({ children }) {
+  const { model } = useConfig();
+  const [status, setStatus] = useState('idle'); // idle | running | done
+  const [events, setEvents] = useState([]);
+  const [record, setRecord] = useState(null);
+  const cancelRef = useRef(false);
+
+  const start = useCallback(async (overrides = {}) => {
+    if (!model || status === 'running') return;
+    cancelRef.current = false;
+    setStatus('running');
+    setEvents([]);
+    setRecord(null);
+
+    const { run, history } = getServices();
+    try {
+      const result = await run.simulate(model, overrides, {
+        onEvent: (e) => setEvents((prev) => [...prev, e]),
+        isCancelled: () => cancelRef.current,
+      });
+      if (cancelRef.current) { setStatus('idle'); return; }
+      setRecord(result);
+      setStatus('done');
+      // Persisting to history must not be able to reclassify a run that already succeeded — a
+      // storage-quota failure here would otherwise be caught below and reported as a failed run.
+      try {
+        await history.add(result);
+      } catch {
+        /* history is a convenience surface; the run itself still succeeded */
+      }
+    } catch (err) {
+      if (cancelRef.current) { setStatus('idle'); return; }
+      // e.g. the HTTP wrapper is unreachable. Surface it as a failed run instead of hanging.
+      const ts = new Date().toISOString();
+      setRecord({
+        runId: makeId('run_error'),
+        configId: model.meta.id,
+        configName: model.meta.name,
+        status: 'failed',
+        startedAt: ts,
+        finishedAt: ts,
+        durationMs: 0,
+        stages: [],
+        logs: [{ type: 'log', ts, level: 'error', message: `Run failed: ${err?.message ?? err}` }],
+        validation: { results: [], summary: { passed: 0, failed: 0, warning: 0, total: 0 } },
+        overrides,
+      });
+      setStatus('done');
+    }
+  }, [model, status]);
+
+  const cancel = useCallback(() => { cancelRef.current = true; }, []);
+
+  return (
+    <RunContext.Provider value={{ status, events, record, start, cancel }}>
+      {children}
+    </RunContext.Provider>
+  );
+}
+
+export function useRun() {
+  const ctx = useContext(RunContext);
+  if (!ctx) throw new Error('useRun must be used within a RunProvider');
+  return ctx;
+}

--- a/frontend/src/state/ViewModeContext.jsx
+++ b/frontend/src/state/ViewModeContext.jsx
@@ -1,0 +1,26 @@
+//  InGen Studio — ViewModeContext
+//
+//  Shared state for the active editor view mode (Graph / Chat). Lives above the
+//  workspace so both the AppShell brand bar (where the switcher lives) and the editor/sidebar
+//  (which render mode-specific content) can read and write the same value.
+
+import { createContext, useContext, useState, useMemo } from 'react';
+
+/**
+ * @typedef {'graph' | 'chat'} ViewMode  (UI labels: graph = inFlow, chat = inChat)
+ * @typedef {{ viewMode: ViewMode, setViewMode: (m: ViewMode) => void }} ViewModeContextValue
+ */
+
+const ViewModeContext = createContext(/** @type {ViewModeContextValue} */ (null));
+
+export function ViewModeProvider({ children }) {
+  const [viewMode, setViewMode] = useState('graph');
+  const value = useMemo(() => ({ viewMode, setViewMode }), [viewMode]);
+  return <ViewModeContext.Provider value={value}>{children}</ViewModeContext.Provider>;
+}
+
+export function useViewMode() {
+  const ctx = useContext(ViewModeContext);
+  if (!ctx) throw new Error('useViewMode must be used within a ViewModeProvider');
+  return ctx;
+}

--- a/frontend/src/state/useModelHistory.js
+++ b/frontend/src/state/useModelHistory.js
@@ -1,0 +1,84 @@
+//  Undo / Redo stack for ConfigModel snapshots.
+//  Keeps at most MAX_HISTORY snapshots; newer pushes beyond that silently drop the oldest.
+//
+//  The stack transitions are pure functions exported alongside the hook, so the state machine is
+//  unit-testable without a React renderer. The hook itself is a thin wrapper over them.
+
+import { useState, useCallback } from 'react';
+
+export const MAX_HISTORY = 50;
+
+/**
+ * Append a snapshot, evicting the oldest once the cap is reached.
+ * @returns {object[]} the new past stack
+ */
+export function pushSnapshot(past, model, max = MAX_HISTORY) {
+  return [...past.slice(-(max - 1)), model];
+}
+
+/**
+ * Move one step back. Returns null when there is nothing to undo.
+ * @returns {{ past: object[], future: object[], restored: object } | null}
+ */
+export function applyUndo(past, future, currentModel) {
+  if (!past.length) return null;
+  return {
+    past: past.slice(0, -1),
+    future: [currentModel, ...future],
+    restored: past[past.length - 1],
+  };
+}
+
+/**
+ * Move one step forward. Returns null when there is nothing to redo.
+ * @returns {{ past: object[], future: object[], restored: object } | null}
+ */
+export function applyRedo(past, future, currentModel) {
+  if (!future.length) return null;
+  return {
+    past: [...past, currentModel],
+    future: future.slice(1),
+    restored: future[0],
+  };
+}
+
+/**
+ * Returns an undo/redo-aware wrapper for a model update function.
+ *
+ * Usage:
+ *   const { pushHistory, undo, redo, canUndo, canRedo } = useModelHistory();
+ *   // call pushHistory(model) BEFORE each mutation so the snapshot captures the pre-mutation state.
+ */
+export function useModelHistory() {
+  const [past, setPast]     = useState([]);   // [...older, immediate-pre-mutation]
+  const [future, setFuture] = useState([]);   // [immediate-post-undo, ...newer]
+
+  const pushHistory = useCallback((model) => {
+    setPast((prev) => pushSnapshot(prev, model));
+    setFuture([]);    // new change clears the redo stack
+  }, []);
+
+  const undo = useCallback((currentModel, setModel) => {
+    const next = applyUndo(past, future, currentModel);
+    if (!next) return;
+    setPast(next.past);
+    setFuture(next.future);
+    setModel(next.restored);
+  }, [past, future]);
+
+  const redo = useCallback((currentModel, setModel) => {
+    const next = applyRedo(past, future, currentModel);
+    if (!next) return;
+    setPast(next.past);
+    setFuture(next.future);
+    setModel(next.restored);
+  }, [past, future]);
+
+  return {
+    pushHistory,
+    undo,
+    redo,
+    canUndo: past.length > 0,
+    canRedo: future.length > 0,
+  };
+}

--- a/frontend/src/state/useModelHistory.test.js
+++ b/frontend/src/state/useModelHistory.test.js
@@ -1,0 +1,155 @@
+//  Tests for the undo/redo state machine that backs useModelHistory.
+//
+//  These exercise the REAL transitions exported from useModelHistory.js (pushSnapshot / applyUndo /
+//  applyRedo) — the hook is a thin useState wrapper over them, so covering the transitions covers
+//  the behaviour without needing a React renderer.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { pushSnapshot, applyUndo, applyRedo, MAX_HISTORY } from './useModelHistory.js';
+
+/** Drive the real transitions through a tiny stateful harness, mirroring what the hook does. */
+function createHistory(max = MAX_HISTORY) {
+  let past = [];
+  let future = [];
+
+  return {
+    get canUndo() { return past.length > 0; },
+    get canRedo() { return future.length > 0; },
+    get depth() { return past.length; },
+    pushHistory(snapshot) {
+      past = pushSnapshot(past, snapshot, max);
+      future = [];  // new edit clears the redo stack
+    },
+    undo(current, apply) {
+      const next = applyUndo(past, future, current);
+      if (!next) return;
+      ({ past, future } = next);
+      apply(next.restored);
+    },
+    redo(current, apply) {
+      const next = applyRedo(past, future, current);
+      if (!next) return;
+      ({ past, future } = next);
+      apply(next.restored);
+    },
+  };
+}
+
+test('initial state: canUndo and canRedo are false', () => {
+  const h = createHistory();
+  assert.equal(h.canUndo, false);
+  assert.equal(h.canRedo, false);
+});
+
+test('pushHistory enables undo', () => {
+  const h = createHistory();
+  h.pushHistory({ v: 1 });
+  assert.equal(h.canUndo, true);
+  assert.equal(h.canRedo, false);
+});
+
+test('undo restores the previous snapshot and enables redo', () => {
+  const h = createHistory();
+  h.pushHistory({ v: 1 });
+  let restored = null;
+  h.undo({ v: 2 }, (m) => { restored = m; });
+  assert.deepEqual(restored, { v: 1 });
+  assert.equal(h.canUndo, false);
+  assert.equal(h.canRedo, true);
+});
+
+test('redo restores the undone state', () => {
+  const h = createHistory();
+  h.pushHistory({ v: 1 });
+  h.undo({ v: 2 }, () => {});
+  let restored = null;
+  h.redo({ v: 1 }, (m) => { restored = m; });
+  assert.deepEqual(restored, { v: 2 });
+  assert.equal(h.canUndo, true);
+  assert.equal(h.canRedo, false);
+});
+
+test('new edit after undo clears the redo stack', () => {
+  const h = createHistory();
+  h.pushHistory({ v: 1 });
+  h.pushHistory({ v: 2 });
+  h.undo({ v: 3 }, () => {});
+  assert.equal(h.canRedo, true);
+  h.pushHistory({ v: 4 }); // new edit
+  assert.equal(h.canRedo, false, 'redo stack cleared after new edit');
+});
+
+test('history respects max size', () => {
+  const h = createHistory(3);
+  h.pushHistory({ v: 1 });
+  h.pushHistory({ v: 2 });
+  h.pushHistory({ v: 3 });
+  h.pushHistory({ v: 4 }); // oldest (v:1) should be evicted
+  let count = 0;
+  while (h.canUndo) { h.undo({ v: 99 }, () => {}); count++; }
+  assert.equal(count, 3, 'max 3 undos');
+});
+
+test('eviction drops the OLDEST snapshot, not the newest', () => {
+  const h = createHistory(2);
+  h.pushHistory({ v: 'oldest' });
+  h.pushHistory({ v: 'middle' });
+  h.pushHistory({ v: 'newest' });
+  const seen = [];
+  while (h.canUndo) h.undo({ v: 'cur' }, (m) => seen.push(m.v));
+  assert.deepEqual(seen, ['newest', 'middle'], 'oldest evicted, order preserved');
+});
+
+test('undo with empty stack is a no-op', () => {
+  const h = createHistory();
+  let called = false;
+  h.undo({ v: 1 }, () => { called = true; });
+  assert.equal(called, false);
+});
+
+test('redo with empty stack is a no-op', () => {
+  const h = createHistory();
+  let called = false;
+  h.redo({ v: 1 }, () => { called = true; });
+  assert.equal(called, false);
+});
+
+test('multiple undo/redo cycles are consistent', () => {
+  const h = createHistory();
+  h.pushHistory({ v: 'a' });
+  h.pushHistory({ v: 'b' });
+  h.pushHistory({ v: 'c' });
+
+  const states = [];
+
+  // Current is 'd', undo back to 'c'
+  h.undo({ v: 'd' }, (m) => states.push(m));
+  assert.deepEqual(states[0], { v: 'c' });
+
+  // Undo to 'b'
+  h.undo({ v: 'c' }, (m) => states.push(m));
+  assert.deepEqual(states[1], { v: 'b' });
+
+  // Redo to 'c'
+  h.redo({ v: 'b' }, (m) => states.push(m));
+  assert.deepEqual(states[2], { v: 'c' });
+
+  // Redo to 'd'
+  h.redo({ v: 'c' }, (m) => states.push(m));
+  assert.deepEqual(states[3], { v: 'd' });
+
+  assert.equal(h.canRedo, false);
+  assert.equal(h.canUndo, true);
+});
+
+test('transitions never mutate the arrays passed in', () => {
+  const past = [{ v: 1 }];
+  const future = [{ v: 2 }];
+  applyUndo(past, future, { v: 3 });
+  applyRedo(past, future, { v: 3 });
+  pushSnapshot(past, { v: 4 });
+  assert.deepEqual(past, [{ v: 1 }], 'past untouched');
+  assert.deepEqual(future, [{ v: 2 }], 'future untouched');
+});


### PR DESCRIPTION
## Summary

Adds the service layer that sits between InGen Studio's UI and its data: pluggable adapters, the
services that wrap them, React context providers for shared state, two small hooks, and a
schema-driven forms engine.

This is part 2 of the frontend series. It is **all new files under `frontend/src/`** — nothing
existing is modified.

| Area | What it does |
|---|---|
| `src/adapters/` | Two interchangeable backends behind one interface — `mock*` (localStorage, no server needed) and `http*` (talks to the FastAPI wrapper). Selected by `NEXT_PUBLIC_ADAPTER_MODE`. |
| `src/services/` | Thin domain wrappers over the adapters — configs, runs, validation, history, catalog, files. |
| `src/state/` | React context providers for config, run, catalog, chat session, graph selection and view mode, plus `useModelHistory` (undo/redo). |
| `src/hooks/` | `useDocTitle`, `useWorkspaceShortcuts`. |
| `src/forms/` | `SchemaForm` + field components — renders the source/column editors from schema definitions rather than hand-written forms. |
| `src/lib/columnStore.js` | Column metadata cache shared across tabs. |

## ⚠️ Please read before reviewing

**This builds on #76 and CI will fail here until #76 merges.** These modules import
`@/models/*` and `@/serializers/*`, which #76 introduces. That is expected — not a defect in this
branch.

The diff itself is **conflict-free and independent**: this PR touches no file that #76 or any other
open PR touches, so it can be merged in any order once #76 lands.

`src/lib/fuzzy.js` and `src/utils/id.js` are **absent by design** — they are already in #76, where
they were needed for that PR's tests to run. This PR does not re-ship them.

## Design notes for reviewers

- **The adapter split is the load-bearing decision.** Every service depends only on the adapter
  interface, so the whole UI runs with zero backend in `mock` mode. That is what makes the app
  demo-able and testable without standing up Python.
- **Contexts are deliberately granular** (six small providers rather than one store) to keep
  re-renders localised. If you'd prefer a single reducer, say so — it's a contained change.
- `useModelHistory` keeps bounded undo/redo stacks with a max size, so long editing sessions don't
  grow memory without limit.

## Testing

Verified on a local integration branch (`main` + #76 + this PR + the two follow-up frontend PRs):

- `npm run test` — 57/57 pass, including this PR's `state/useModelHistory.test.js`
- `npm run build` — full `next build` compiles clean, all 6 routes generated
- `npm run dev` in mock mode — browser smoke pass over start screen → editor → run console, **0
  console errors**
- Backend untouched by this PR, but re-verified alongside it: `pytest test/` and
  `pytest backend/tests/` (42 passed) show no new failures

### Quality gates

All green on the integration branch:

| Gate | Result |
|---|---|
| `npm run lint` | 0 errors, 0 warnings |
| `npm run test` | 57 / 57 |
| `npm run build` | compiles, all 6 routes generated |
| `pytest test/` | no new failures vs. baseline |
| `pytest backend/tests/` | 42 passed |

## What it looks like

The schema-driven forms engine in action — this source editor is **not hand-written JSX**. It is
generated from a field-descriptor array in `src/forms/schemas/`, which is what keeps source,
pre-processor, formatter and output forms from being four copies of the same code:

![Schema-driven source form](https://raw.githubusercontent.com/maan-iitd2/ingen/pr-assets/screenshots/09-schema-driven-form.png)

The state and adapter layers in this PR are what keep the YAML panel on the right in sync on every
edit.

> Shown running as part of the complete Studio on a local integration branch, since this PR alone
> does not render an app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

