### PR TITLE
feat(frontend): interface editor - tabs, inFlow graph canvas, inChat panel

### DIFF
--- a/frontend/src/components/editor/InterfaceEditor.jsx
+++ b/frontend/src/components/editor/InterfaceEditor.jsx
@@ -1,0 +1,44 @@
+//  InGen Studio — InterfaceEditor (PRIMARY screen)
+//
+//  Edits one interface at a time. Supports two view modes via ViewModeContext:
+//    - Graph (inFlow): React Flow visual pipeline editor
+//    - Chat (inChat): ChatGPT-like natural language conversational editor
+//  The view switcher is in the brand bar — this component just reads the mode.
+
+import { useParams } from 'next/navigation';
+
+import { useConfig } from '../../state/ConfigContext.jsx';
+import { useViewMode } from '../../state/ViewModeContext.jsx';
+
+import dynamic from 'next/dynamic';
+import InterfaceChatEditor from './chat/InterfaceChatEditor.jsx';
+
+// Lazy-load the graph editor so reactflow (v11, not fully React 19 compatible) is only fetched
+// when the user switches to graph mode — keeps the initial bundle clean and avoids the webpack
+// module-resolution crash ("Cannot read properties of undefined (reading 'call')").
+const InterfaceGraphEditor = dynamic(
+  () => import('./graph/InterfaceGraphEditor.jsx'),
+  { ssr: false, loading: () => <div className="placeholder">Loading graph editor…</div> },
+);
+
+export default function InterfaceEditor() {
+  const { interfaceName } = useParams();
+  const { model } = useConfig();
+  const { viewMode } = useViewMode();
+
+  const iface = model?.interfacesByName?.[interfaceName];
+
+  if (!iface) {
+    return <div className="placeholder">Interface "{interfaceName}" not found in this config.</div>;
+  }
+
+  return (
+    <section className="editor editor--full">
+      <div className="editor__panel">
+        {viewMode === 'chat'
+          ? <InterfaceChatEditor interfaceName={interfaceName} iface={iface} />
+          : <InterfaceGraphEditor interfaceName={interfaceName} iface={iface} />}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/editor/InterfaceManager.jsx
+++ b/frontend/src/components/editor/InterfaceManager.jsx
@@ -1,0 +1,190 @@
+//  InterfaceManager — rendered inside WorkspaceLayout above the NavRail.
+//  Lets users: switch interfaces, rename them (inline), add new ones, and delete them.
+
+import { useState, useRef, useLayoutEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { Plus, Trash2, Pencil, Check, X } from 'lucide-react';
+
+import { useConfig } from '../../state/ConfigContext.jsx';
+import {
+  createEmptyInterface,
+  upsertInterface,
+  removeInterface,
+  renameInterface,
+} from '../../models/configModel.js';
+import ConfirmDialog from '../common/ConfirmDialog.jsx';
+
+export default function InterfaceManager({ configId }) {
+  const router = useRouter();
+  const { interfaceName: activeIface } = useParams() || {};
+  const { model, updateModel } = useConfig();
+
+  const [editingName, setEditingName] = useState(null);  // name being renamed
+  const [editValue, setEditValue] = useState('');
+  const [confirmDel, setConfirmDel] = useState(null);    // name to delete
+  const [addingNew, setAddingNew] = useState(false);
+  const [newName, setNewName] = useState('');
+  const inputRef = useRef(null);
+
+  const interfaces = model?.interfaceOrder ?? [];
+  const newNameTaken = Boolean(model?.interfacesByName?.[newName.trim()]);
+  const newNameValid = newName.trim().length > 0 && !newNameTaken;
+
+  // ── Rename ────────────────────────────────────────────────────────────────
+  useLayoutEffect(() => {
+    if (editingName) inputRef.current?.select();
+  }, [editingName]);
+
+  useLayoutEffect(() => {
+    if (addingNew) inputRef.current?.focus();
+  }, [addingNew]);
+
+  const startRename = (name) => {
+    setEditingName(name);
+    setEditValue(name);
+  };
+
+  const commitRename = () => {
+    const next = editValue.trim();
+    if (next && next !== editingName) {
+      try {
+        updateModel((m) => renameInterface(m, editingName, next));
+        // Navigate to the renamed interface if it was active.
+        if (editingName === activeIface) {
+          router.replace(`/configs/${configId}/interfaces/${encodeURIComponent(next)}`);
+        }
+      } catch { /* duplicate name — ignore */ }
+    }
+    setEditingName(null);
+  };
+
+  const cancelRename = () => setEditingName(null);
+
+  // ── Add ───────────────────────────────────────────────────────────────────
+  const commitAdd = () => {
+    const name = newName.trim();
+    if (!newNameValid) return;
+    updateModel((m) => upsertInterface(m, name, createEmptyInterface()));
+    setAddingNew(false);
+    setNewName('');
+    router.push(`/configs/${configId}/interfaces/${encodeURIComponent(name)}`);
+  };
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+  const doDelete = () => {
+    if (!confirmDel) return;
+    const wasActive = confirmDel === activeIface;
+    updateModel((m) => removeInterface(m, confirmDel));
+    setConfirmDel(null);
+    if (wasActive) {
+      const remaining = interfaces.filter((n) => n !== confirmDel);
+      if (remaining.length > 0)
+        router.replace(`/configs/${configId}/interfaces/${encodeURIComponent(remaining[0])}`);
+      else
+        router.replace(`/configs/${configId}`);
+    }
+  };
+
+  if (interfaces.length === 0) return null;
+
+  return (
+    <div className="ifmgr">
+      <div className="ifmgr__head">
+        <span className="ifmgr__label">Interfaces</span>
+        <button
+          className="ifmgr__add-btn"
+          title="Add interface"
+          onClick={() => { setAddingNew(true); setNewName(''); }}
+        >
+          <Plus size={13} />
+        </button>
+      </div>
+
+      <ul className="ifmgr__list">
+        {interfaces.map((name) => (
+          <li
+            key={name}
+            className={`ifmgr__item${name === activeIface ? ' ifmgr__item--active' : ''}`}
+          >
+            {editingName === name ? (
+              <div className="ifmgr__rename">
+                <input
+                  ref={inputRef}
+                  className="ifmgr__rename-input"
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={commitRename}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitRename();
+                    if (e.key === 'Escape') cancelRename();
+                  }}
+                />
+                <button className="ifmgr__icon-btn" onMouseDown={(e) => { e.preventDefault(); commitRename(); }} title="Confirm">
+                  <Check size={12} />
+                </button>
+                <button className="ifmgr__icon-btn ifmgr__icon-btn--cancel" onMouseDown={(e) => { e.preventDefault(); cancelRename(); }} title="Cancel">
+                  <X size={12} />
+                </button>
+              </div>
+            ) : (
+              <>
+                <button
+                  className="ifmgr__name-btn"
+                  onClick={() => router.push(`/configs/${configId}/interfaces/${encodeURIComponent(name)}`)}
+                >
+                  {name}
+                </button>
+                <div className="ifmgr__actions">
+                  <button className="ifmgr__icon-btn" title="Rename" onClick={() => startRename(name)}>
+                    <Pencil size={11} />
+                  </button>
+                  <button
+                    className="ifmgr__icon-btn ifmgr__icon-btn--danger"
+                    title="Delete interface"
+                    disabled={interfaces.length <= 1}
+                    onClick={() => setConfirmDel(name)}
+                  >
+                    <Trash2 size={11} />
+                  </button>
+                </div>
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {addingNew && (
+        <div className="ifmgr__new">
+          <input
+            ref={editingName ? undefined : inputRef}
+            className={`ifmgr__rename-input${newNameTaken ? ' ifmgr__rename-input--err' : ''}`}
+            placeholder="interface_name"
+            value={newName}
+            autoFocus
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && newNameValid) commitAdd();
+              if (e.key === 'Escape') { setAddingNew(false); setNewName(''); }
+            }}
+          />
+          <button className="ifmgr__icon-btn" disabled={!newNameValid} onMouseDown={(e) => { e.preventDefault(); commitAdd(); }} title="Create">
+            <Check size={12} />
+          </button>
+          <button className="ifmgr__icon-btn ifmgr__icon-btn--cancel" onMouseDown={(e) => { e.preventDefault(); setAddingNew(false); setNewName(''); }} title="Cancel">
+            <X size={12} />
+          </button>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={Boolean(confirmDel)}
+        title="Delete interface"
+        message={`Delete interface "${confirmDel}"? All its columns, transforms, and output config will be lost. This can't be undone.`}
+        confirmLabel="Delete"
+        danger
+        onConfirm={doDelete}
+        onCancel={() => setConfirmDel(null)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/editor/chat/InterfaceChatEditor.jsx
+++ b/frontend/src/components/editor/chat/InterfaceChatEditor.jsx
@@ -1,0 +1,236 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { Bot, User, Sparkles } from 'lucide-react';
+import { useConfig } from '../../../state/ConfigContext.jsx';
+import { useChatSession } from '../../../state/ChatSessionContext.jsx';
+import { applyOps } from '../../../models/applyIntent.js';
+import { getServices } from '../../../services/index.js';
+import { columnsForSources } from '../../../lib/columnStore.js';
+import { modelToYaml } from '../../../serializers/yamlSerializer.js';
+import MiniMarkdown from '../../common/MiniMarkdown.jsx';
+import {
+  getActiveSession,
+  getSessions,
+  saveSession,
+  createSession,
+} from '../../../services/chatHistoryService.js';
+
+function welcomeMessage(interfaceName) {
+  return {
+    id: 'welcome',
+    sender: 'assistant',
+    text: `Hi! I'm **inChat**, your pipeline assistant for **${interfaceName}**. Tell me what you want in plain language — I'll wire up sources, filters, and output for you. The suggestions below are tailored to what you've built so far.`,
+  };
+}
+
+// Regex fallback — used when the local model is unavailable. Returns the SAME ops shape the backend
+// produces, so a single applier handles both paths.
+// Op authority: frontend/src/models/applyIntent.js — only emit ops it implements.
+function regexOps(text) {
+  const t = text.trim();
+  let m;
+  if ((m = t.match(/^add\s+columns?\s+(.+)/i))) {
+    const cols = m[1].split(/[,\s]+/).map((s) => s.trim()).filter(Boolean);
+    return cols.length ? [{ op: 'add_columns', cols }] : [];
+  }
+  if ((m = t.match(/^remove\s+columns?\s+(\S+)/i))) return [{ op: 'remove_column', name: m[1] }];
+  if ((m = t.match(/^rename\s+(\w+)\s+(?:to\s+)?(\w+)/i))) return [{ op: 'rename_column', from: m[1], to: m[2] }];
+  if ((m = t.match(/^add\s+source\s+(\w+)\s+(\w+)/i))) return [{ op: 'add_source', name: m[1], type: m[2].toLowerCase() }];
+  if ((m = t.match(/^remove\s+source\s+(\S+)/i))) return [{ op: 'remove_source', name: m[1] }];
+  if ((m = t.match(/^add\s+transform\s+(\w+)/i))) return [{ op: 'add_transform', type: m[1].toLowerCase() }];
+  if ((m = t.match(/^remove\s+transform\s+(\w+)/i))) return [{ op: 'remove_transform', type: m[1].toLowerCase() }];
+  if ((m = t.match(/^filter\s+(\w+)\s+(.+)/i))) return [{ op: 'add_filter', col: m[1], val: m[2] }];
+  if ((m = t.match(/^change\s+output\s+to\s+(\w+)/i))) return [{ op: 'set_output', type: m[1].toLowerCase() }];
+  if (/^(explain|describe|what.*(pipeline|interface))/i.test(t)) return [{ op: 'explain' }];
+  return [];
+}
+
+// Suggestion chips derived from current state — always valid, never LLM-guessed.
+function suggestionsFor(iface, columns) {
+  const out = [];
+  out.push('explain');
+  if (columns.length) out.push(`add columns ${columns.slice(0, 3).join(', ')}`);
+  else if ((iface?.columns?.length ?? 0) === 0) out.push('add columns id, status, amount');
+  const col = columns[0] || (iface?.columns?.[0]?.src_col_name);
+  if (col) out.push(`filter ${col} CLOSED`);
+  if (!iface?.output?.type) out.push('change output to excel');
+  return out.slice(0, 4);
+}
+
+export default function InterfaceChatEditor({ interfaceName, iface }) {
+  const { model, updateModel } = useConfig();
+  const { setActiveSessionId, command, consumeCommand } = useChatSession();
+  const [sessionId, setSessionId] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const [isTyping, setIsTyping] = useState(false);
+  const messagesEndRef = useRef(null);
+
+  const knownColumns = columnsForSources(iface?.sources ?? []);
+
+  // Pre-warm the local model once when the chat opens, so the first message isn't slow.
+  useEffect(() => { getServices().chat.warmup(); }, []);
+
+  //  Load (or start) the conversation for whichever interface is being edited. Done during render
+  //  rather than in an effect — React's "adjust state when a prop changes" pattern — so switching
+  //  interfaces never paints one frame of the previous interface's messages.
+  const [loadedFor, setLoadedFor] = useState(null);
+  if (loadedFor !== interfaceName) {
+    setLoadedFor(interfaceName);
+    const active = getActiveSession(interfaceName);
+    if (active && active.messages.length > 0) {
+      setSessionId(active.id);
+      setMessages(active.messages);
+    } else {
+      setSessionId(createSession().id);
+      setMessages([welcomeMessage(interfaceName)]);
+    }
+  }
+
+  useEffect(() => {
+    if (sessionId) setActiveSessionId(sessionId);
+  }, [sessionId, setActiveSessionId]);
+
+  //  One-shot commands from the sidebar (new conversation / load conversation).
+  //
+  //  This genuinely has to be an effect, so the set-state-in-effect rule is suppressed below:
+  //  consumeCommand() calls setCommand(null) on ChatSessionProvider, and updating another
+  //  component's state during render is illegal in React ("Cannot update a component while
+  //  rendering a different component"). The command is cleared on receipt, so this runs exactly
+  //  once per command and cannot cascade.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (!command) return;
+    if (command.kind === 'new') {
+      setSessionId(createSession().id);
+      setMessages([welcomeMessage(interfaceName)]);
+      consumeCommand();
+    } else if (command.kind === 'load' && command.interfaceName === interfaceName) {
+      const target = getSessions(interfaceName).find((s) => s.id === command.sessionId);
+      if (target) {
+        setSessionId(target.id);
+        setMessages(target.messages.length ? target.messages : [welcomeMessage(interfaceName)]);
+      }
+      consumeCommand();
+    }
+  }, [command, interfaceName, consumeCommand]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  useEffect(() => {
+    if (sessionId && messages.length > 0) {
+      saveSession(interfaceName, { id: sessionId, messages, createdAt: new Date().toISOString() });
+    }
+  }, [messages, sessionId, interfaceName]);
+
+  const scrollToBottom = () => messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  useEffect(() => { scrollToBottom(); }, [messages, isTyping]);
+
+  const handleSendMessage = useCallback((textToSend) => {
+    if (!textToSend.trim()) return;
+    // Recent dialogue (before this new turn) so the model can resolve follow-ups like "now also add X".
+    const history = messages
+      .filter((m) => m.id !== 'welcome')
+      .slice(-6)
+      .map((m) => ({ role: m.sender === 'user' ? 'user' : 'assistant', content: m.text }));
+    setMessages((prev) => [...prev, { id: `msg-${Date.now()}`, sender: 'user', text: textToSend }]);
+    setInputValue('');
+    setIsTyping(true);
+
+    // Snapshot YAML from current model for the LLM context, then fire the request.
+    const yaml = (() => { try { return modelToYaml(model); } catch { return ''; } })();
+    getServices().chat.interpret(textToSend, knownColumns, yaml, interfaceName, history)
+      .catch(() => ({ ops: regexOps(textToSend), reply: '' }))
+      .then(({ ops, reply: modelReply }) => {
+        // Apply ops inside the functional updater so they always thread through the LATEST
+        // committed model — not the stale closure snapshot — preventing concurrent-message races.
+        let reply = '';
+        let changed = false;
+        updateModel((currentModel) => {
+          const result = applyOps(currentModel, interfaceName, knownColumns, ops);
+          reply = result.reply;
+          changed = result.changed;
+          return result.model;
+        });
+        const isConversation = (ops?.length ?? 0) === 0;
+        const text = modelReply && (changed || isConversation) ? modelReply : reply;
+        setMessages((prev) => [...prev, { id: `msg-reply-${Date.now()}`, sender: 'assistant', text }]);
+      })
+      .catch(() => {
+        setMessages((prev) => [...prev, {
+          id: `msg-reply-${Date.now()}`,
+          sender: 'assistant',
+          text: "Sorry — I couldn't apply that change. Please try rephrasing it.",
+        }]);
+      })
+      // Always clear the indicator: if applyOps throws above, the spinner would otherwise never stop.
+      .finally(() => setIsTyping(false));
+  }, [model, updateModel, interfaceName, knownColumns, messages]);
+
+  const chips = suggestionsFor(iface, knownColumns);
+
+  const fmtTime = (id) => {
+    const ts = parseInt(id?.split('-').pop(), 10);
+    if (!ts || Number.isNaN(ts)) return '';
+    return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  return (
+    <div className="chateditor">
+      <div className="chateditor__messages">
+        {messages.map((m) => (
+          <div key={m.id} className={`chatbubble chatbubble--${m.sender}`}>
+            <div className={`chatbubble__avatar chatbubble__avatar--${m.sender}`} aria-hidden="true">
+              {m.sender === 'user' ? <User size={14} /> : <Bot size={14} />}
+            </div>
+            <div className="chatbubble__body">
+              {m.sender === 'assistant'
+                ? <MiniMarkdown text={m.text} className="chatbubble__content chatbubble__content--assistant" />
+                : <div className="chatbubble__content chatbubble__content--user">{m.text}</div>
+              }
+              {m.id !== 'welcome' && (
+                <span className="chatbubble__time">{fmtTime(m.id)}</span>
+              )}
+            </div>
+          </div>
+        ))}
+        {isTyping && (
+          <div className="chatbubble chatbubble--assistant">
+            <div className="chatbubble__avatar chatbubble__avatar--assistant" aria-hidden="true">
+              <Bot size={14} />
+            </div>
+            <div className="chatbubble__body">
+              <div className="chatbubble__content chatbubble__content--assistant">
+                <div className="typing-indicator"><span></span><span></span><span></span></div>
+              </div>
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="chateditor__inputarea">
+        <div className="prompt-chips">
+          {chips.map((c) => (
+            <button key={c} className="prompt-chip" onClick={() => handleSendMessage(c)}>
+              {c === 'explain' ? <><Sparkles size={11} /> explain</> : `+ ${c}`}
+            </button>
+          ))}
+        </div>
+
+        <form className="chateditor__form" onSubmit={(e) => { e.preventDefault(); handleSendMessage(inputValue); }}>
+          <input
+            type="text"
+            className="chateditor__input"
+            placeholder="Describe a change to your pipeline…"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            disabled={isTyping}
+            autoComplete="off"
+          />
+          <button type="submit" className="btn btn--accent" disabled={!inputValue.trim() || isTyping} style={{ padding: '10px 20px' }}>
+            Send
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/editor/graph/ContextMenu.jsx
+++ b/frontend/src/components/editor/graph/ContextMenu.jsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react';
+import { Pencil, Trash2, Maximize2, LayoutDashboard, Unplug } from 'lucide-react';
+
+/**
+ * @param {{
+ *   x: number, y: number,
+ *   type: 'node' | 'edge' | 'pane',
+ *   nodeId?: string,
+ *   nodeType?: string,
+ *   edgeId?: string,
+ *   onClose: () => void,
+ *   onEdit?: () => void,
+ *   onDelete?: () => void,
+ *   onDisconnect?: () => void,
+ *   onFitView?: () => void,
+ *   onAutoLayout?: () => void,
+ * }} props
+ */
+export default function ContextMenu({
+  x, y, type, onClose,
+  onEdit, onDelete, onDisconnect,
+  onFitView, onAutoLayout,
+}) {
+  const ref = useRef(null);
+
+  // Close on outside click or Escape.
+  useEffect(() => {
+    const handler = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) onClose();
+    };
+    const keyHandler = (e) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('mousedown', handler);
+    document.addEventListener('keydown', keyHandler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+      document.removeEventListener('keydown', keyHandler);
+    };
+  }, [onClose]);
+
+  const item = (icon, label, fn, danger = false) => (
+    <button
+      className={`graph-ctxmenu__item${danger ? ' graph-ctxmenu__item--danger' : ''}`}
+      onClick={() => { fn(); onClose(); }}
+    >
+      {icon} {label}
+    </button>
+  );
+
+  return (
+    <div ref={ref} className="graph-ctxmenu" style={{ left: x, top: y }}>
+      {type === 'node' && (
+        <div className="graph-ctxmenu__section">
+          {onEdit    && item(<Pencil   size={13} />, 'Edit properties', onEdit)}
+          {onDisconnect && item(<Unplug size={13} />, 'Disconnect all edges', onDisconnect)}
+          {onDelete  && item(<Trash2   size={13} />, 'Delete node', onDelete, true)}
+        </div>
+      )}
+      {type === 'edge' && (
+        <div className="graph-ctxmenu__section">
+          {onDelete && item(<Trash2 size={13} />, 'Delete connection', onDelete, true)}
+        </div>
+      )}
+      {(type === 'pane' || type === 'node') && (
+        <div className="graph-ctxmenu__section">
+          {onFitView     && item(<Maximize2      size={13} />, 'Fit view',    onFitView)}
+          {onAutoLayout  && item(<LayoutDashboard size={13} />, 'Auto layout', onAutoLayout)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/editor/graph/GraphToolbar.jsx
+++ b/frontend/src/components/editor/graph/GraphToolbar.jsx
@@ -1,0 +1,48 @@
+import { useReactFlow } from 'reactflow';
+import { Maximize2, LayoutDashboard, Undo2, Redo2, ZoomIn, ZoomOut } from 'lucide-react';
+
+/**
+ * Floating top-centre toolbar mirroring n8n's canvas controls.
+ *
+ * @param {{
+ *   onAutoLayout: () => void,
+ *   canUndo: boolean,
+ *   canRedo: boolean,
+ *   onUndo: () => void,
+ *   onRedo: () => void,
+ *   zoom: number,
+ * }} props
+ */
+export default function GraphToolbar({ onAutoLayout, canUndo, canRedo, onUndo, onRedo, zoom }) {
+  const { fitView, zoomIn, zoomOut } = useReactFlow();
+
+  return (
+    <div className="grapheditor__topbar">
+      <button className="grapheditor__topbar-btn" title="Fit view (F)" onClick={() => fitView({ padding: 0.2, duration: 300 })}>
+        <Maximize2 size={13} /> Fit view
+      </button>
+      <button className="grapheditor__topbar-btn" title="Auto layout" onClick={onAutoLayout}>
+        <LayoutDashboard size={13} /> Layout
+      </button>
+
+      <div className="grapheditor__topbar-sep" />
+
+      <button className="grapheditor__topbar-btn" title="Undo (Ctrl+Z)" onClick={onUndo} disabled={!canUndo}>
+        <Undo2 size={13} />
+      </button>
+      <button className="grapheditor__topbar-btn" title="Redo (Ctrl+Shift+Z)" onClick={onRedo} disabled={!canRedo}>
+        <Redo2 size={13} />
+      </button>
+
+      <div className="grapheditor__topbar-sep" />
+
+      <button className="grapheditor__topbar-btn" title="Zoom out" onClick={() => zoomOut({ duration: 150 })}>
+        <ZoomOut size={13} />
+      </button>
+      <span className="grapheditor__zoom-pct">{Math.round(zoom * 100)}%</span>
+      <button className="grapheditor__topbar-btn" title="Zoom in" onClick={() => zoomIn({ duration: 150 })}>
+        <ZoomIn size={13} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/editor/graph/InterfaceGraphEditor.jsx
+++ b/frontend/src/components/editor/graph/InterfaceGraphEditor.jsx
@@ -1,0 +1,646 @@
+import { useEffect, useMemo, useCallback, useState, useRef } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  MiniMap,
+  Panel,
+  MarkerType,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+  ReactFlowProvider,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import { X, Trash2 } from 'lucide-react';
+
+import { useConfig } from '../../../state/ConfigContext.jsx';
+import { useSourceActions } from '../../../hooks/useSourceActions.js';
+import { useGraphSelection } from '../../../state/GraphSelectionContext.jsx';
+import SchemaForm from '../../../forms/SchemaForm.jsx';
+import { preProcessorSchema, PRE_PROCESSOR_SCHEMAS } from '../../../forms/schemas/preProcessorSchemas.js';
+import { sourceSchema } from '../../../forms/schemas/sourceSchemas.js';
+import { upsertSource, removeSource } from '../../../models/configModel.js';
+import SourceActionDialog from '../../common/SourceActionDialog.jsx';
+
+import SourcesTab from '../tabs/SourcesTab.jsx';
+import ColumnsTab from '../tabs/ColumnsTab.jsx';
+import PostProcessingTab from '../tabs/PostProcessingTab.jsx';
+import ValidationsTab from '../tabs/ValidationsTab.jsx';
+import OutputTab from '../tabs/OutputTab.jsx';
+
+import { STAGE, SOURCE_CONSUMERS, wiredSources, SRC, PRE, FLOW_STYLE, CONN_STYLE } from './graphConstants.js';
+import { SourceNode }     from './nodes/SourceNode.jsx';
+import { PreprocessNode } from './nodes/PreprocessNode.jsx';
+import { ColumnsNode }    from './nodes/ColumnsNode.jsx';
+import { PostprocessNode } from './nodes/PostprocessNode.jsx';
+import { ValidationsNode } from './nodes/ValidationsNode.jsx';
+import { OutputNode }     from './nodes/OutputNode.jsx';
+import { applyDagreLayout } from './useGraphLayout.js';
+import ContextMenu from './ContextMenu.jsx';
+import GraphToolbar from './GraphToolbar.jsx';
+
+// These must be stable (defined outside the component) to avoid ReactFlow re-rendering all nodes.
+const defaultEdgeOptions = { type: 'smoothstep' };
+const nodeTypes = {
+  source:      SourceNode,
+  preprocess:  PreprocessNode,
+  columns:     ColumnsNode,
+  postprocess: PostprocessNode,
+  validations: ValidationsNode,
+  output:      OutputNode,
+};
+
+const miniMapColor = (n) =>
+  STAGE[n.type === 'preprocess'  ? 'transform'
+       : n.type === 'postprocess' ? 'post'
+       : n.type === 'validations' ? 'validation'
+       : n.type] || STAGE.output;
+
+// ── Inner component (needs ReactFlowProvider wrapper for useReactFlow) ─────
+
+function GraphEditorInner({ interfaceName, iface }) {
+  const { model, updateInterface, updateModel, undo, redo, canUndo, canRedo } = useConfig();
+  const { selectedNodeId, setSelectedNodeId } = useGraphSelection();
+  const { fitView, getZoom } = useReactFlow();
+
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [zoom, setZoom] = useState(1);
+  const [ctxMenu, setCtxMenu] = useState(null); // { x, y, type, nodeId?, nodeType?, edgeId? }
+  // Track whether initial auto-layout was applied so we don't re-layout on every model change.
+  const didInitLayout = useRef(false);
+
+  // Merging a source adds nodes, so let the next render re-run the auto-layout.
+  const { pendingSourceAction, setPendingSourceAction, handleNewInterface, handleMergeSource } =
+    useSourceActions(interfaceName, { onMerged: () => { didInitLayout.current = false; } });
+
+  // Leaving graph mode clears the shared selection.
+  useEffect(() => () => setSelectedNodeId(null), [setSelectedNodeId]);
+
+  //  fitView has to run after ReactFlow has committed the new node positions, so it is deferred by
+  //  a tick. Track the pending timers and clear them on unmount — otherwise navigating away within
+  //  the delay fires fitView against an unmounted ReactFlow instance.
+  const fitTimers = useRef([]);
+  const scheduleFitView = useCallback((delay) => {
+    fitTimers.current.push(setTimeout(() => fitView({ padding: 0.2, duration: 300 }), delay));
+  }, [fitView]);
+  useEffect(() => () => {
+    fitTimers.current.forEach(clearTimeout);
+    fitTimers.current = [];
+  }, []);
+
+  const apply = useCallback((fn) => updateInterface(interfaceName, fn), [updateInterface, interfaceName]);
+
+  // ── Build nodes + edges from the model ──────────────────────────────────
+  useEffect(() => {
+    const newNodes = [];
+    const newEdges = [];
+
+    const sources       = iface.sources        ?? [];
+    const preProcesses  = iface.pre_processing  ?? [];
+    const columns       = iface.columns         ?? [];
+    const postProcess   = iface.post_processing ?? [];
+    const validationCount = columns.reduce((n, c) => n + (c.validations?.length ?? 0), 0);
+    const output        = iface.output ?? {};
+
+    const baseSid    = sources[0];
+    const referenced = new Set();
+    preProcesses.forEach((step) => wiredSources(step).forEach((sid) => referenced.add(sid)));
+
+    let colIndex = 0;
+    const colWidth = 300;
+
+    sources.forEach((sid, idx) => {
+      newNodes.push({
+        id: `${SRC}${sid}`,
+        type: 'source',
+        position: { x: colIndex * colWidth + 40, y: 60 + idx * 160 },
+        data: {
+          label: sid,
+          details: model.sourcesById?.[sid],
+          role: sid === baseSid ? 'base' : 'secondary',
+          unused: sid !== baseSid && !referenced.has(sid),
+          selected: false,
+        },
+      });
+    });
+    if (sources.length > 0) colIndex++;
+
+    preProcesses.forEach((step, idx) => {
+      newNodes.push({
+        id: `${PRE}${idx}`,
+        type: 'preprocess',
+        position: { x: colIndex * colWidth + 40, y: 60 + idx * 160 },
+        data: {
+          label: PRE_PROCESSOR_SCHEMAS[step.type]?.label || step.type,
+          index: idx,
+          details: step,
+          selected: false,
+        },
+      });
+    });
+    if (preProcesses.length > 0) colIndex++;
+
+    const columnsNodeId = 'columns-node';
+    newNodes.push({
+      id: columnsNodeId,
+      type: 'columns',
+      position: { x: colIndex * colWidth + 40, y: 140 },
+      data: {
+        label: 'Columns Mapping',
+        count: columns.length,
+        columnNames: columns.map((c) => c.dest_col_name || c.src_col_name).filter(Boolean),
+        selected: false,
+      },
+    });
+    colIndex++;
+
+    const postNodeId = 'post-node';
+    const hasPost = postProcess.length > 0;
+    if (hasPost) {
+      newNodes.push({
+        id: postNodeId,
+        type: 'postprocess',
+        position: { x: colIndex * colWidth + 40, y: 140 },
+        data: { label: 'Post-processing', steps: postProcess, selected: false },
+      });
+      colIndex++;
+    }
+
+    const validationNodeId = 'validation-node';
+    newNodes.push({
+      id: validationNodeId,
+      type: 'validations',
+      position: { x: colIndex * colWidth + 40, y: 140 },
+      data: { label: 'GE Validations', count: validationCount, selected: false },
+    });
+    colIndex++;
+
+    const outputNodeId = 'output-node';
+    newNodes.push({
+      id: outputNodeId,
+      type: 'output',
+      position: { x: colIndex * colWidth + 40, y: 140 },
+      data: { label: 'Output Destination', details: output, selected: false },
+    });
+
+    const flow = (id, source, target) => ({
+      id, source, target,
+      type: 'smoothstep',
+      sourceHandle: 'out', targetHandle: 'in',
+      animated: true, style: FLOW_STYLE,
+      markerEnd: { type: MarkerType.ArrowClosed, color: STAGE.columns, width: 16, height: 16 },
+    });
+
+    const chainStart = preProcesses.length > 0 ? `${PRE}0` : columnsNodeId;
+    if (baseSid) newEdges.push(flow(`flow-base-${chainStart}`, `${SRC}${baseSid}`, chainStart));
+
+    preProcesses.forEach((_, idx) => {
+      const next = idx < preProcesses.length - 1 ? `${PRE}${idx + 1}` : columnsNodeId;
+      newEdges.push(flow(`flow-pre${idx}`, `${PRE}${idx}`, next));
+    });
+
+    let tail = columnsNodeId;
+    if (hasPost) {
+      newEdges.push(flow('flow-cols-post', columnsNodeId, postNodeId));
+      tail = postNodeId;
+    }
+    newEdges.push(flow('flow-tail-val', tail, validationNodeId));
+    newEdges.push(flow('flow-val-out', validationNodeId, outputNodeId));
+
+    preProcesses.forEach((step, idx) => {
+      const spec = SOURCE_CONSUMERS[step.type];
+      if (!spec) return;
+      wiredSources(step).forEach((sid) => {
+        if (!model.sourcesById?.[sid] && !(iface.sources ?? []).includes(sid)) return;
+        newEdges.push({
+          id: `feed-${sid}-pre${idx}`,
+          source: `${SRC}${sid}`, target: `${PRE}${idx}`,
+          type: 'smoothstep',
+          sourceHandle: 'out', targetHandle: 'src-in',
+          data: { feed: true, sid, preIdx: idx },
+          label: spec.tag,
+          labelStyle: { fill: STAGE.source, fontSize: 10, fontFamily: 'var(--mono)', fontWeight: 600 },
+          labelBgStyle: { fill: '#fff', stroke: STAGE.source, strokeWidth: 1 },
+          labelBgPadding: [5, 3], labelBgBorderRadius: 5,
+          style: { stroke: STAGE.source, strokeWidth: 1.6, strokeDasharray: '5 4' },
+          markerEnd: { type: MarkerType.Arrow, color: STAGE.source },
+        });
+      });
+    });
+
+    // Apply dagre layout on first mount only; subsequent model changes keep user-dragged positions.
+    if (!didInitLayout.current) {
+      const laid = applyDagreLayout(newNodes, newEdges);
+      setNodes(laid.nodes);
+      setEdges(laid.edges);
+      didInitLayout.current = true;
+      scheduleFitView(60);
+    } else {
+      setNodes(newNodes);
+      setEdges(newEdges);
+    }
+  }, [iface, model, setNodes, setEdges, scheduleFitView]);
+
+  // Selection highlight (no position rebuild).
+  useEffect(() => {
+    setNodes((nds) =>
+      nds.map((n) => ({ ...n, data: { ...n.data, selected: n.id === selectedNodeId } }))
+    );
+  }, [selectedNodeId, setNodes]);
+
+  // Track zoom level for the toolbar display.
+  const onMoveEnd = useCallback(() => setZoom(getZoom()), [getZoom]);
+
+  // ── Connection logic ─────────────────────────────────────────────────────
+  const feedConnectionSpec = useCallback((conn) => {
+    if (!conn.source?.startsWith(SRC) || !conn.target?.startsWith(PRE)) return null;
+    if (conn.targetHandle && conn.targetHandle !== 'src-in') return null;
+    const idx = parseInt(conn.target.slice(PRE.length), 10);
+    const step = iface.pre_processing?.[idx];
+    const spec = step && SOURCE_CONSUMERS[step.type];
+    if (!spec) return null;
+    return { kind: 'feed', idx, sid: conn.source.slice(SRC.length), spec };
+  }, [iface]);
+
+  const chainConnectionSpec = useCallback((conn) => {
+    if (!conn.source?.startsWith(SRC)) return null;
+    const sid = conn.source.slice(SRC.length);
+    if (conn.target?.startsWith(PRE) && (!conn.targetHandle || conn.targetHandle === 'in'))
+      return { kind: 'chain', sid };
+    if (['columns-node', 'post-node', 'validation-node', 'output-node'].includes(conn.target))
+      return { kind: 'chain', sid };
+    return null;
+  }, []);
+
+  const isValidConnection = useCallback(
+    (conn) => Boolean(feedConnectionSpec(conn) || chainConnectionSpec(conn)),
+    [feedConnectionSpec, chainConnectionSpec],
+  );
+
+  const onConnect = useCallback((conn) => {
+    const feed = feedConnectionSpec(conn);
+    if (feed) {
+      const { idx, sid, spec } = feed;
+      apply((it) => {
+        const list = [...(it.pre_processing ?? [])];
+        const cur = { ...list[idx] };
+        if (spec.multi) {
+          const arr = Array.isArray(cur[spec.param]) ? cur[spec.param] : cur[spec.param] ? [cur[spec.param]] : [];
+          if (!arr.includes(sid)) cur[spec.param] = [...arr, sid];
+        } else {
+          cur[spec.param] = sid;
+        }
+        list[idx] = cur;
+        return { ...it, pre_processing: list };
+      });
+      return;
+    }
+    const chain = chainConnectionSpec(conn);
+    if (chain) {
+      const currentSources = iface.sources ?? [];
+      if (currentSources.length > 0 && !currentSources.includes(chain.sid)) {
+        setPendingSourceAction({ sid: chain.sid });
+      } else {
+        apply((it) => {
+          const cur = it.sources ?? [];
+          if (cur.includes(chain.sid)) {
+            return { ...it, sources: [chain.sid, ...cur.filter((s) => s !== chain.sid)] };
+          }
+          return { ...it, sources: [chain.sid, ...cur] };
+        });
+      }
+    }
+  }, [apply, iface, feedConnectionSpec, chainConnectionSpec, setPendingSourceAction]);
+
+  // ── Source action handlers (new interface / merge) ─────────────────────────
+
+
+  const onEdgesDelete = useCallback((deleted) => {
+    deleted.forEach((e) => {
+      if (!e.data?.feed) return;
+      const { preIdx: idx, sid } = e.data;
+      apply((it) => {
+        const list = [...(it.pre_processing ?? [])];
+        const step = list[idx];
+        const spec = step && SOURCE_CONSUMERS[step.type];
+        if (!spec) return it;
+        const cur = { ...step };
+        if (spec.multi) {
+          const raw = cur[spec.param];
+          const arr = Array.isArray(raw) ? raw : raw ? [raw] : [];
+          cur[spec.param] = arr.filter((s) => s !== sid);
+        } else if (cur[spec.param] === sid) {
+          delete cur[spec.param];
+        }
+        list[idx] = cur;
+        return { ...it, pre_processing: list };
+      });
+    });
+  }, [apply]);
+
+  // Delete selected nodes/edges via keyboard (Delete / Backspace handled by ReactFlow natively
+  // through deleteKeyCode; onNodesDelete + onEdgesDelete handle the model side).
+  const onNodesDelete = useCallback((deleted) => {
+    deleted.forEach((n) => {
+      if (n.id.startsWith(PRE)) {
+        const idx = parseInt(n.id.slice(PRE.length), 10);
+        apply((it) => ({ ...it, pre_processing: (it.pre_processing ?? []).filter((_, i) => i !== idx) }));
+        setSelectedNodeId(null);
+      }
+    });
+  }, [apply, setSelectedNodeId]);
+
+  const onNodeClick = useCallback((_e, node) => {
+    setSelectedNodeId((prev) => (prev === node.id ? null : node.id));
+    setCtxMenu(null);
+  }, [setSelectedNodeId]);
+
+  // ── Drag-from-palette ───────────────────────────────────────────────────
+  const pendingSelectRef = useRef(null);
+  const onDrop = useCallback((event) => {
+    event.preventDefault();
+    const raw = event.dataTransfer.getData('application/reactflow');
+    if (!raw) return;
+    const nodeData = JSON.parse(raw);
+    if (nodeData.type === 'transformNode' && nodeData.subtype) {
+      const newIdx = iface.pre_processing?.length ?? 0;
+      apply((i) => ({ ...i, pre_processing: [...(i.pre_processing ?? []), { type: nodeData.subtype }] }));
+      pendingSelectRef.current = `${PRE}${newIdx}`;
+    }
+  }, [apply, iface]);
+
+  // Use a ref+effect instead of setTimeout to defer selection after the drop re-render.
+  useEffect(() => {
+    if (pendingSelectRef.current) {
+      setSelectedNodeId(pendingSelectRef.current);
+      pendingSelectRef.current = null;
+    }
+  });
+
+  const onDragOver = useCallback((event) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  // ── Auto layout ─────────────────────────────────────────────────────────
+  const handleAutoLayout = useCallback(() => {
+    setNodes((nds) => {
+      const { nodes: laid } = applyDagreLayout(nds, edges);
+      return laid;
+    });
+    scheduleFitView(50);
+  }, [setNodes, edges, scheduleFitView]);
+
+  // ── Context menu handlers ───────────────────────────────────────────────
+  const onNodeContextMenu = useCallback((e, node) => {
+    e.preventDefault();
+    setCtxMenu({ x: e.clientX, y: e.clientY, type: 'node', nodeId: node.id, nodeType: node.type });
+  }, []);
+
+  const onEdgeContextMenu = useCallback((e, edge) => {
+    e.preventDefault();
+    setCtxMenu({ x: e.clientX, y: e.clientY, type: 'edge', edgeId: edge.id, edgeData: edge.data });
+  }, []);
+
+  const onPaneContextMenu = useCallback((e) => {
+    e.preventDefault();
+    setCtxMenu({ x: e.clientX, y: e.clientY, type: 'pane' });
+  }, []);
+
+  const closeCtx = useCallback(() => setCtxMenu(null), []);
+
+  const ctxEdit = ctxMenu?.nodeId
+    ? () => { setSelectedNodeId(ctxMenu.nodeId); }
+    : undefined;
+
+  const ctxDelete = ctxMenu
+    ? () => {
+        if (ctxMenu.type === 'node') {
+          if (ctxMenu.nodeId?.startsWith(SRC)) {
+            const srcId = ctxMenu.nodeId.slice(SRC.length);
+            updateModel((m) => removeSource(m, srcId));
+            apply((it) => ({ ...it, sources: (it.sources ?? []).filter((s) => s !== srcId) }));
+            setSelectedNodeId(null);
+          } else if (ctxMenu.nodeId?.startsWith(PRE)) {
+            const idx = parseInt(ctxMenu.nodeId.slice(PRE.length), 10);
+            apply((it) => ({ ...it, pre_processing: (it.pre_processing ?? []).filter((_, i) => i !== idx) }));
+            setSelectedNodeId(null);
+          }
+        }
+        if (ctxMenu.type === 'edge' && ctxMenu.edgeData?.feed) {
+          onEdgesDelete([{ data: ctxMenu.edgeData }]);
+        }
+        closeCtx();
+      }
+    : undefined;
+
+  const ctxDisconnect = ctxMenu?.nodeId
+    ? () => {
+        setEdges((eds) => eds.filter((e) => e.source !== ctxMenu.nodeId && e.target !== ctxMenu.nodeId));
+        closeCtx();
+      }
+    : undefined;
+
+  // ── Keyboard shortcuts ───────────────────────────────────────────────────
+  //  Graph-local only. Undo/redo are deliberately NOT bound here: useWorkspaceShortcuts (mounted
+  //  by WorkspaceLayout, which wraps this editor) already binds Ctrl+Z / Ctrl+Y to the same
+  //  useConfig() undo/redo. Binding them in both places popped two history entries per keypress.
+  useEffect(() => {
+    const handler = (e) => {
+      const tag = document.activeElement?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (e.key === 'f' || e.key === 'F') fitView({ padding: 0.2, duration: 300 });
+      if (e.key === 'Escape') { setSelectedNodeId(null); closeCtx(); }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [fitView, setSelectedNodeId, closeCtx]);
+
+  // ── Drawer content ───────────────────────────────────────────────────────
+  const drawerContent = useMemo(() => {
+    if (!selectedNodeId) return null;
+    if (selectedNodeId === 'columns-node')
+      return { title: 'Columns mapping',           Component: <ColumnsTab interfaceName={interfaceName} iface={iface} /> };
+    if (selectedNodeId === 'post-node')
+      return { title: 'Post-processing (pivot)',    Component: <PostProcessingTab interfaceName={interfaceName} iface={iface} /> };
+    if (selectedNodeId === 'validation-node')
+      return { title: 'Validation expectations',   Component: <ValidationsTab interfaceName={interfaceName} iface={iface} /> };
+    if (selectedNodeId === 'output-node')
+      return { title: 'Output destination',        Component: <OutputTab interfaceName={interfaceName} iface={iface} /> };
+    if (selectedNodeId.startsWith('src-')) {
+      const srcId  = selectedNodeId.slice(SRC.length);
+      const srcDef = model.sourcesById?.[srcId];
+      if (srcDef) {
+        const schema = sourceSchema(srcDef.type);
+        return {
+          title: `Source: ${srcId}`,
+          Component: (
+            <div className="tabcontent">
+              <div className="src-editor-header">
+                <span className="src-editor-id">{srcId}</span>
+                <span className="src-editor-type" style={{ color: STAGE.source }}>{srcDef.type}</span>
+              </div>
+              {schema.length > 0 ? (
+                <SchemaForm
+                  key={srcId}
+                  schema={schema}
+                  value={srcDef}
+                  onChange={(next) => updateModel((m) => upsertSource(m, { ...next, id: srcId, type: srcDef.type }))}
+                />
+              ) : (
+                <p className="tabcontent__hint">This source type has no configurable properties.</p>
+              )}
+              <hr style={{ border: 'none', borderTop: '1px solid var(--border-light)', margin: '16px 0' }} />
+              <details>
+                <summary style={{ fontSize: '12px', color: 'var(--text-muted)', cursor: 'pointer', marginBottom: 8 }}>All interface sources</summary>
+                <SourcesTab interfaceName={interfaceName} iface={iface} />
+              </details>
+            </div>
+          ),
+        };
+      }
+      return { title: 'Interface sources', Component: <SourcesTab interfaceName={interfaceName} iface={iface} /> };
+    }
+    if (selectedNodeId.startsWith('pre-')) {
+      const idx  = parseInt(selectedNodeId.split('-')[1], 10);
+      const step = iface.pre_processing?.[idx];
+      if (!step) return null;
+      return {
+        title: `Transform: ${PRE_PROCESSOR_SCHEMAS[step.type]?.label || step.type}`,
+        Component: (
+          <div className="tabcontent">
+            <SchemaForm
+              schema={preProcessorSchema(step.type)}
+              value={step}
+              ctx={{ sources: model.sourceOrder }}
+              onChange={(next) =>
+                apply((it) => {
+                  const updated = [...(it.pre_processing ?? [])];
+                  updated[idx] = { ...next, type: step.type };
+                  return { ...it, pre_processing: updated };
+                })
+              }
+            />
+            <button
+              className="btn btn--danger"
+              style={{ width: '100%', marginTop: 16, justifyContent: 'center' }}
+              onClick={() => {
+                apply((it) => ({ ...it, pre_processing: (it.pre_processing ?? []).filter((_, i) => i !== idx) }));
+                setSelectedNodeId(null);
+              }}
+            >
+              <Trash2 size={14} /> Remove step
+            </button>
+          </div>
+        ),
+      };
+    }
+    return null;
+  }, [selectedNodeId, iface, interfaceName, model, apply, setSelectedNodeId, updateModel]);
+
+  return (
+    <div className="grapheditor">
+      <div className="grapheditor__canvas" onDrop={onDrop} onDragOver={onDragOver}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onEdgesDelete={onEdgesDelete}
+          onNodesDelete={onNodesDelete}
+          isValidConnection={isValidConnection}
+          onNodeClick={onNodeClick}
+          onNodeContextMenu={onNodeContextMenu}
+          onEdgeContextMenu={onEdgeContextMenu}
+          onPaneContextMenu={onPaneContextMenu}
+          onPaneClick={closeCtx}
+          onMoveEnd={onMoveEnd}
+          nodeTypes={nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.2 }}
+          snapToGrid
+          snapGrid={[20, 20]}
+          selectionOnDrag
+          multiSelectionKeyCode="Shift"
+          deleteKeyCode={['Backspace', 'Delete']}
+          defaultEdgeOptions={defaultEdgeOptions}
+          connectionMode="loose"
+          connectionRadius={40}
+          connectionLineStyle={CONN_STYLE}
+        >
+          <Background color={STAGE.columns} variant="dots" opacity={0.06} gap={20} size={1.5} />
+          <Controls showInteractive />
+          <MiniMap pannable zoomable nodeColor={miniMapColor} maskColor="rgba(248, 247, 255, 0.7)" />
+
+          <Panel position="top-center" style={{ margin: 0 }}>
+            <GraphToolbar
+              onAutoLayout={handleAutoLayout}
+              canUndo={canUndo}
+              canRedo={canRedo}
+              onUndo={undo}
+              onRedo={redo}
+              zoom={zoom}
+            />
+          </Panel>
+        </ReactFlow>
+
+        <div className="grapheditor__legend">
+          <span className="grapheditor__legend-item"><i className="leg leg--flow" /> data flow</span>
+          <span className="grapheditor__legend-item"><i className="leg leg--feed" /> source feed → YAML</span>
+        </div>
+
+        {ctxMenu && (
+          <ContextMenu
+            x={ctxMenu.x} y={ctxMenu.y}
+            type={ctxMenu.type}
+            nodeId={ctxMenu.nodeId}
+            onClose={closeCtx}
+            onEdit={ctxEdit}
+            onDelete={
+              ctxMenu?.type === 'edge' ||
+              ctxMenu?.nodeId?.startsWith(SRC) ||
+              ctxMenu?.nodeId?.startsWith(PRE)
+                ? ctxDelete
+                : undefined
+            }
+            onDisconnect={ctxDisconnect}
+            onFitView={() => { fitView({ padding: 0.2, duration: 300 }); closeCtx(); }}
+            onAutoLayout={() => { handleAutoLayout(); closeCtx(); }}
+          />
+        )}
+      </div>
+
+      {selectedNodeId && drawerContent && (
+        <div className="grapheditor__drawer">
+          <div className="grapheditor__drawer-head">
+            <span className="grapheditor__drawer-title">{drawerContent.title}</span>
+            <button className="grapheditor__drawer-close" onClick={() => setSelectedNodeId(null)}>
+              <X size={16} />
+            </button>
+          </div>
+          <div className="grapheditor__drawer-body">{drawerContent.Component}</div>
+        </div>
+      )}
+
+      <SourceActionDialog
+        open={Boolean(pendingSourceAction)}
+        sourceId={pendingSourceAction?.sid ?? ''}
+        onNewInterface={handleNewInterface}
+        onMerge={handleMergeSource}
+        onCancel={() => setPendingSourceAction(null)}
+      />
+    </div>
+  );
+}
+
+// ── Public export: wraps with ReactFlowProvider ────────────────────────────
+
+export default function InterfaceGraphEditor(props) {
+  return (
+    <ReactFlowProvider>
+      <GraphEditorInner {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/frontend/src/components/editor/graph/graphConstants.js
+++ b/frontend/src/components/editor/graph/graphConstants.js
@@ -1,0 +1,38 @@
+//  Shared stage palette, constants, and source-consumer contract for the graph editor.
+
+export const STAGE = {
+  source: '#3b82f6',
+  transform: '#f59e0b',
+  columns: '#7853EC',
+  post: '#ec4899',
+  validation: '#10b981',
+  output: '#ef4444',
+};
+
+// Pre-processors that pull in a SECONDARY source. Wiring a source node into one of these writes the
+// named YAML field; `multi` types accept a list (union/melt), the rest a single id. `tag` labels the
+// dashed feed edge so the relationship is legible on the canvas. Mirrors preProcessorSchemas.js.
+export const SOURCE_CONSUMERS = {
+  merge:             { param: 'source',          multi: false, tag: 'right' },
+  outer_join:        { param: 'source',          multi: false, tag: 'right' },
+  mask:              { param: 'masking_source',  multi: false, tag: 'mask' },
+  not_equals_filter: { param: 'source',          multi: false, tag: 'exclude' },
+  union:             { param: 'source',          multi: true,  tag: '∪' },
+  melt:              { param: 'source',          multi: true,  tag: 'melt' },
+};
+
+/** Read a consumer's wired source ids as an array (handles single vs list params + stray scalars). */
+export function wiredSources(step) {
+  const spec = SOURCE_CONSUMERS[step?.type];
+  if (!spec) return [];
+  const v = step[spec.param];
+  if (v == null || v === '') return [];
+  return Array.isArray(v) ? v.filter(Boolean) : [v];
+}
+
+export const tr = (s, n = 28) => (s && s.length > n ? s.slice(0, n) + '…' : s);
+export const SRC = 'src-';
+export const PRE = 'pre-';
+
+export const FLOW_STYLE  = { stroke: STAGE.columns, strokeWidth: 2 };
+export const CONN_STYLE  = { stroke: STAGE.source, strokeWidth: 1.8, strokeDasharray: '5 4' };

--- a/frontend/src/components/editor/graph/nodes/ColumnsNode.jsx
+++ b/frontend/src/components/editor/graph/nodes/ColumnsNode.jsx
@@ -1,0 +1,24 @@
+import { Handle, Position } from 'reactflow';
+import { Columns } from 'lucide-react';
+import { STAGE } from '../graphConstants.js';
+import { CustomNodeHeader } from './NodeShared.jsx';
+
+export function ColumnsNode({ data }) {
+  const shown = (data.columnNames || []).slice(0, 5);
+  const more = (data.count || 0) - shown.length;
+
+  return (
+    <div className={`custom-node${data.selected ? ' custom-node--selected' : ''}`} style={{ borderLeft: `5px solid ${STAGE.columns}` }}>
+      <Handle type="target" position={Position.Left} id="in" className="rf-handle rf-handle--in" />
+      <CustomNodeHeader icon={<Columns size={14} />} title="Columns" type={`${data.count} mapped`} color={STAGE.columns} />
+      <div className="custom-node__body">
+        <div className="custom-node__collist">
+          {shown.map((name) => <span key={name} className="custom-node__colchip">{name}</span>)}
+          {more > 0 && <span className="custom-node__colmore">+{more} more</span>}
+          {data.count === 0 && <span className="custom-node__info">No columns defined</span>}
+        </div>
+      </div>
+      <Handle type="source" position={Position.Right} id="out" className="rf-handle rf-handle--out" />
+    </div>
+  );
+}

--- a/frontend/src/components/editor/graph/nodes/NodeShared.jsx
+++ b/frontend/src/components/editor/graph/nodes/NodeShared.jsx
@@ -1,0 +1,28 @@
+//  Shared primitives used by all custom node types.
+
+export const PropTable = ({ rows }) => {
+  const visible = rows.filter((r) => r.value != null && r.value !== '');
+  if (!visible.length) return null;
+  return (
+    <div className="custom-node__props">
+      {visible.map(({ key, value }) => (
+        <div key={key} className="custom-node__prop-row">
+          <span className="custom-node__prop-key">{key}</span>
+          <span className="custom-node__prop-val">{String(value)}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const CustomNodeHeader = ({ icon, title, type, color }) => (
+  <div className="custom-node__header">
+    <div className="custom-node__icon-box" style={{ backgroundColor: `${color}18`, color }}>
+      {icon}
+    </div>
+    <div style={{ minWidth: 0 }}>
+      <div className="custom-node__title">{title}</div>
+      <div className="custom-node__type">{type}</div>
+    </div>
+  </div>
+);

--- a/frontend/src/components/editor/graph/nodes/OutputNode.jsx
+++ b/frontend/src/components/editor/graph/nodes/OutputNode.jsx
@@ -1,0 +1,23 @@
+import { Handle, Position } from 'reactflow';
+import { FileOutput } from 'lucide-react';
+import { STAGE, tr } from '../graphConstants.js';
+import { CustomNodeHeader, PropTable } from './NodeShared.jsx';
+
+export function OutputNode({ data }) {
+  const d = data.details || {};
+  const rows = [
+    { key: 'type',  value: d.type },
+    { key: 'path',  value: d.props?.path        ? tr(d.props.path)      : null },
+    { key: 'sheet', value: d.props?.sheet_name  || null },
+  ];
+
+  return (
+    <div className={`custom-node${data.selected ? ' custom-node--selected' : ''}`} style={{ borderLeft: `5px solid ${STAGE.output}` }}>
+      <Handle type="target" position={Position.Left} id="in" className="rf-handle rf-handle--in" />
+      <CustomNodeHeader icon={<FileOutput size={14} />} title="Output" type="Writer" color={STAGE.output} />
+      <div className="custom-node__body">
+        <PropTable rows={rows} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/editor/graph/nodes/PostprocessNode.jsx
+++ b/frontend/src/components/editor/graph/nodes/PostprocessNode.jsx
@@ -1,0 +1,25 @@
+import { Handle, Position } from 'reactflow';
+import { ArrowRightLeft } from 'lucide-react';
+import { STAGE } from '../graphConstants.js';
+import { CustomNodeHeader, PropTable } from './NodeShared.jsx';
+
+export function PostprocessNode({ data }) {
+  const step = (data.steps || [])[0] || {};
+  const pv = step.processing_values || {};
+  const rows = [
+    { key: 'type',  value: step.type    || null },
+    { key: 'pivot', value: pv.pivot_col || null },
+    { key: 'value', value: pv.value_col || null },
+  ];
+
+  return (
+    <div className={`custom-node${data.selected ? ' custom-node--selected' : ''}`} style={{ borderLeft: `5px solid ${STAGE.post}` }}>
+      <Handle type="target" position={Position.Left} id="in" className="rf-handle rf-handle--in" />
+      <CustomNodeHeader icon={<ArrowRightLeft size={14} />} title="Post-processing" type="Reshape" color={STAGE.post} />
+      <div className="custom-node__body">
+        <PropTable rows={rows} />
+      </div>
+      <Handle type="source" position={Position.Right} id="out" className="rf-handle rf-handle--out" />
+    </div>
+  );
+}

--- a/frontend/src/components/editor/graph/nodes/PreprocessNode.jsx
+++ b/frontend/src/components/editor/graph/nodes/PreprocessNode.jsx
@@ -1,0 +1,56 @@
+import { Handle, Position } from 'reactflow';
+import { Filter, Plug } from 'lucide-react';
+import { STAGE, SOURCE_CONSUMERS, wiredSources } from '../graphConstants.js';
+import { CustomNodeHeader, PropTable } from './NodeShared.jsx';
+
+export function PreprocessNode({ data }) {
+  const s = data.details || {};
+  const spec = SOURCE_CONSUMERS[s.type];
+  const wired = wiredSources(s);
+  const rows = [{ key: 'type', value: s.type }];
+  if (s.type === 'merge' || s.type === 'outer_join') {
+    if (s.merge_type) rows.push({ key: 'join', value: s.merge_type });
+    if (s.left_key && s.right_key) rows.push({ key: 'on', value: `${s.left_key} = ${s.right_key}` });
+  }
+  if (s.type === 'not_equals_filter') {
+    const cols = s.cols || [];
+    if (cols.length)
+      rows.push({ key: 'filter', value: `${cols[0].col} ≠ ${(cols[0].val || []).join(',')}${cols.length > 1 ? ` +${cols.length - 1}` : ''}` });
+  }
+  if (s.type === 'aggregate') {
+    rows.push({ key: 'group', value: (s.groupby?.cols || []).join(', ') || '—' });
+  }
+
+  return (
+    <div className={`custom-node${data.selected ? ' custom-node--selected' : ''}`} style={{ borderLeft: `5px solid ${STAGE.transform}` }}>
+      <Handle type="target" position={Position.Left} id="in" className="rf-handle rf-handle--in" />
+      <CustomNodeHeader
+        icon={<Filter size={14} />}
+        title={`${data.index + 1}. ${data.label}`}
+        type="Transform"
+        color={STAGE.transform}
+      />
+      {spec && (
+        <>
+          <Handle type="target" position={Position.Top} id="src-in" className="rf-handle rf-handle--feed" title="Patch a source here" />
+          <span className="custom-node__feedport" aria-hidden="true">
+            <Plug size={9} /> source
+          </span>
+        </>
+      )}
+      <div className="custom-node__body">
+        <PropTable rows={rows} />
+        {spec && (
+          <div className="custom-node__feeds">
+            {wired.length ? (
+              wired.map((sid) => <span key={sid} className="custom-node__feedchip">{sid}</span>)
+            ) : (
+              <span className="custom-node__feedhint">needs a {spec.tag} source</span>
+            )}
+          </div>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} id="out" className="rf-handle rf-handle--out" />
+    </div>
+  );
+}

--- a/frontend/src/components/editor/graph/nodes/SourceNode.jsx
+++ b/frontend/src/components/editor/graph/nodes/SourceNode.jsx
@@ -1,0 +1,36 @@
+import { Handle, Position } from 'reactflow';
+import { Database } from 'lucide-react';
+import { STAGE, tr } from '../graphConstants.js';
+import { CustomNodeHeader, PropTable } from './NodeShared.jsx';
+
+export function SourceNode({ data }) {
+  const d = data.details || {};
+  const rows = [{ key: 'type', value: d.type }];
+  if (d.file_type) rows.push({ key: 'format', value: d.file_type });
+  if (d.file_path) rows.push({ key: 'path', value: tr(d.file_path) });
+  if (d.database || d.db_token) rows.push({ key: 'db', value: d.database || d.db_token });
+  if (d.url) rows.push({ key: 'url', value: tr(d.url) });
+
+  const cls =
+    'custom-node' +
+    (data.selected ? ' custom-node--selected' : '') +
+    (data.unused ? ' custom-node--unused' : '');
+
+  return (
+    <div className={cls} style={{ borderLeft: `5px solid ${STAGE.source}` }}>
+      <CustomNodeHeader
+        icon={<Database size={14} />}
+        title={data.label}
+        type={data.role === 'base' ? 'Base input' : 'Source'}
+        color={STAGE.source}
+      />
+      <div className="custom-node__body">
+        <PropTable rows={rows} />
+        {data.unused && (
+          <span className="custom-node__warn">Not wired — drag its port into a transform</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} id="out" className="rf-handle rf-handle--out" />
+    </div>
+  );
+}

--- a/frontend/src/components/editor/graph/nodes/ValidationsNode.jsx
+++ b/frontend/src/components/editor/graph/nodes/ValidationsNode.jsx
@@ -1,0 +1,17 @@
+import { Handle, Position } from 'reactflow';
+import { ShieldCheck } from 'lucide-react';
+import { STAGE } from '../graphConstants.js';
+import { CustomNodeHeader, PropTable } from './NodeShared.jsx';
+
+export function ValidationsNode({ data }) {
+  return (
+    <div className={`custom-node${data.selected ? ' custom-node--selected' : ''}`} style={{ borderLeft: `5px solid ${STAGE.validation}` }}>
+      <Handle type="target" position={Position.Left} id="in" className="rf-handle rf-handle--in" />
+      <CustomNodeHeader icon={<ShieldCheck size={14} />} title="Validations" type="GE expectations" color={STAGE.validation} />
+      <div className="custom-node__body">
+        <PropTable rows={[{ key: 'count', value: data.count || 0 }]} />
+      </div>
+      <Handle type="source" position={Position.Right} id="out" className="rf-handle rf-handle--out" />
+    </div>
+  );
+}

--- a/frontend/src/components/editor/graph/useGraphLayout.js
+++ b/frontend/src/components/editor/graph/useGraphLayout.js
@@ -1,0 +1,35 @@
+import dagre from '@dagrejs/dagre';
+
+const NODE_WIDTH  = 260;
+const NODE_HEIGHT = 120;
+
+/**
+ * Compute left-to-right dagre layout for the given nodes + edges.
+ * Returns new arrays with updated `position` on each node.
+ * Does NOT mutate the originals.
+ *
+ * @param {import('reactflow').Node[]} nodes
+ * @param {import('reactflow').Edge[]} edges
+ * @returns {{ nodes: import('reactflow').Node[], edges: import('reactflow').Edge[] }}
+ */
+export function applyDagreLayout(nodes, edges) {
+  const g = new dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  g.setGraph({ rankdir: 'LR', nodesep: 60, ranksep: 120, marginx: 40, marginy: 40 });
+
+  nodes.forEach((n) => {
+    g.setNode(n.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  });
+  edges.forEach((e) => {
+    g.setEdge(e.source, e.target);
+  });
+
+  dagre.layout(g);
+
+  const laid = nodes.map((n) => {
+    const { x, y } = g.node(n.id);
+    return { ...n, position: { x: x - NODE_WIDTH / 2, y: y - NODE_HEIGHT / 2 } };
+  });
+
+  return { nodes: laid, edges };
+}

--- a/frontend/src/components/editor/tabs/ColumnsTab.jsx
+++ b/frontend/src/components/editor/tabs/ColumnsTab.jsx
@@ -1,0 +1,287 @@
+//  Columns & Formatters editor — card-based layout with clear source → dest mapping.
+//  Source columns are chosen from a dropdown of headers detected for the interface's sources
+//  (files auto-detect on upload; SQL/API are fetched on demand via the "Fetch columns" button).
+
+import { useReducer, useState } from 'react';
+import { Plus, ArrowRight, ChevronDown, ChevronUp, Columns, RefreshCw, AlertCircle, Loader2 } from 'lucide-react';
+import { useConfig } from '../../../state/ConfigContext.jsx';
+import { useCatalog } from '../../../state/CatalogContext.jsx';
+import SchemaForm from '../../../forms/SchemaForm.jsx';
+import ListControls from '../../common/ListControls.jsx';
+import { listAdd, listUpdate, listRemove, listMove } from '../../../models/interfaceOps.js';
+import { formatterSchema } from '../../../forms/schemas/formatterSchemas.js';
+import { columnsForSources, getColumns, setColumns } from '../../../lib/columnStore.js';
+import { fetchSourceColumns } from '../../../services/fileService.js';
+
+function FormatterRow({ formatter, index, count, onChange, onMove, onRemove }) {
+  return (
+    <div className="colcard__fmt-row">
+      <div className="colcard__fmt-head">
+        <span className="chip chip--mono">{formatter.type}</span>
+        <ListControls index={index} count={count} onMove={onMove} onRemove={onRemove} />
+      </div>
+      <SchemaForm
+        schema={formatterSchema(formatter.type)}
+        value={formatter}
+        onChange={(next) => onChange({ ...next, type: formatter.type })}
+      />
+    </div>
+  );
+}
+
+// Strict dropdown: choose a source column from detected headers. An already-saved value that isn't
+// in the detected list is kept as an option so editing a column never silently drops it.
+function SourceColSelect({ value, options, onChange, onFetch }) {
+  const opts = value && !options.includes(value) ? [value, ...options] : options;
+  if (opts.length === 0) {
+    return (
+      <button type="button" className="colcard__colpick-empty" onClick={onFetch}>
+        No columns detected — fetch
+      </button>
+    );
+  }
+  return (
+    <select
+      className="colcard__input colcard__input--select"
+      value={value ?? ''}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="" disabled>Select a column…</option>
+      {opts.map((c) => <option key={c} value={c}>{c}</option>)}
+    </select>
+  );
+}
+
+function ColumnCard({ col, index, count, isExpanded, onToggle, onUpdate, onRemove, onMove, formatterTypes, onUpdateFmts, srcColumns, onFetch }) {
+  const fmts = col.formatters ?? [];
+  const [addFmt, setAddFmt] = useState('date');
+
+  return (
+    <div className={`colcard${isExpanded ? ' colcard--expanded' : ''}`}>
+      <div className="colcard__main">
+        <div className="colcard__rank">{index + 1}</div>
+
+        <div className="colcard__mapping">
+          <div className="colcard__field">
+            <label className="colcard__field-label">Source</label>
+            <SourceColSelect
+              value={col.src_col_name ?? ''}
+              options={srcColumns}
+              onChange={(v) => onUpdate({ ...col, src_col_name: v })}
+              onFetch={onFetch}
+            />
+          </div>
+
+          <div className="colcard__arrow">
+            <ArrowRight size={16} />
+          </div>
+
+          <div className="colcard__field">
+            <label className="colcard__field-label">Output</label>
+            <input
+              className="colcard__input"
+              placeholder={col.src_col_name || 'dest_col_name'}
+              value={col.dest_col_name ?? ''}
+              onChange={(e) => onUpdate({ ...col, dest_col_name: e.target.value || undefined })}
+            />
+          </div>
+        </div>
+
+        <div className="colcard__actions">
+          <div className="colcard__actions-row">
+            <button className="lctrls__btn" title="Move up" aria-label="Move up" disabled={index === 0} onClick={() => onMove(-1)}>↑</button>
+            <button className="lctrls__btn" title="Move down" aria-label="Move down" disabled={index === count - 1} onClick={() => onMove(1)}>↓</button>
+          </div>
+          <div className="colcard__actions-row">
+            {/* Formatter badge / toggle */}
+            <button
+              className={`colcard__fmt-badge${isExpanded ? ' colcard__fmt-badge--open' : ''}${fmts.length > 0 ? ' colcard__fmt-badge--has' : ''}`}
+              onClick={onToggle}
+              title={fmts.length > 0 ? `${fmts.length} formatter(s) — click to edit` : 'Add a formatter'}
+            >
+              {fmts.length > 0
+                ? <>{fmts.length} fmt{fmts.length !== 1 ? 's' : ''} {isExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}</>
+                : <><Plus size={12} /> fmt</>
+              }
+            </button>
+
+            <button className="lctrls__btn lctrls__btn--del" title="Remove" aria-label="Remove" onClick={onRemove}>✕</button>
+          </div>
+        </div>
+      </div>
+
+      {/* Expanded formatter editor */}
+      {isExpanded && (
+        <div className="colcard__fmt-body">
+          {fmts.map((f, fi) => (
+            <FormatterRow
+              key={fi}
+              formatter={f}
+              index={fi}
+              count={fmts.length}
+              onChange={(nf) => {
+                const next = [...fmts];
+                next[fi] = nf;
+                onUpdateFmts(next);
+              }}
+              onMove={(d) => {
+                const t = fi + d;
+                if (t < 0 || t >= fmts.length) return;
+                const arr = [...fmts];
+                [arr[fi], arr[t]] = [arr[t], arr[fi]];
+                onUpdateFmts(arr);
+              }}
+              onRemove={() => onUpdateFmts(fmts.filter((_, idx) => idx !== fi))}
+            />
+          ))}
+          <div className="colcard__fmt-add">
+            <select
+              className="field__input"
+              value={addFmt}
+              onChange={(e) => setAddFmt(e.target.value)}
+            >
+              {formatterTypes.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+            <button
+              className="btn btn--ghost-dark btn--xs"
+              onClick={() => onUpdateFmts([...fmts, { type: addFmt }])}
+            >
+              <Plus size={12} /> Add formatter
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function ColumnsTab({ interfaceName, iface }) {
+  const { model, updateInterface } = useConfig();
+  const { catalog } = useCatalog();
+  const columns = iface.columns ?? [];
+  const sources = iface.sources ?? [];
+  const formatterTypes = catalog?.formatters ?? [];
+  const [expandedIdx, setExpandedIdx] = useState(null);
+
+  // columnStore writes to localStorage (not reactive) — bump this to re-read after a fetch.
+  const [, refresh] = useReducer((x) => x + 1, 0);
+  const [fetching, setFetching] = useState(false);
+  const [fetchErr, setFetchErr] = useState('');
+
+  const srcColumns = columnsForSources(sources);
+
+  // Fetch headers for every source on this interface that doesn't have them cached yet
+  // (uploaded files already do — this covers SQL/API and typed file paths).
+  const fetchColumns = async () => {
+    setFetching(true);
+    setFetchErr('');
+    try {
+      for (const sid of sources) {
+        const src = model.sourcesById[sid];
+        if (!src || getColumns(sid).length) continue;
+        setColumns(sid, await fetchSourceColumns(src));
+      }
+      refresh();
+    } catch (e) {
+      setFetchErr(e.message || 'Fetch failed');
+    } finally {
+      setFetching(false);
+    }
+  };
+
+  const apply = (fn) => updateInterface(interfaceName, fn);
+
+  const toggleExpand = (i) => setExpandedIdx((prev) => (prev === i ? null : i));
+
+  const removeCol = (i) => {
+    apply((it) => listRemove(it, 'columns', i));
+    setExpandedIdx((prev) => {
+      if (prev === i) return null;
+      if (prev > i) return prev - 1;
+      return prev;
+    });
+  };
+
+  // Reorder while keeping the expanded card following its column (so the open formatter editor
+  // stays on the row the user is editing, not whichever column lands at that index).
+  const moveCol = (i, d) => {
+    apply((it) => listMove(it, 'columns', i, d));
+    setExpandedIdx((prev) => (prev === i ? i + d : prev === i + d ? i : prev));
+  };
+
+  const updateFmts = (colIdx, col, fmts) =>
+    apply((it) => listUpdate(it, 'columns', colIdx, { ...col, formatters: fmts.length ? fmts : undefined }));
+
+  const addColumn = () => apply((it) => listAdd(it, 'columns', { src_col_name: '' }));
+
+  return (
+    <div className="tabcontent">
+      <div className="colcard-header">
+        <p className="tabcontent__hint">
+          Map source columns to output columns. Pick the source column from its detected headers.
+        </p>
+        <div className="colcard-header__actions">
+          {sources.length > 0 && (
+            <button className="btn btn--ghost btn--xs" onClick={fetchColumns} disabled={fetching}>
+              {fetching ? <Loader2 size={13} className="spin" /> : <RefreshCw size={13} />} Fetch columns
+            </button>
+          )}
+          {columns.length > 0 && (
+            <button className="btn btn--solid btn--xs" onClick={addColumn}>
+              <Plus size={13} /> Add column
+            </button>
+          )}
+        </div>
+      </div>
+
+      {fetchErr && (
+        <p className="colcard-fetch-err"><AlertCircle size={13} /> {fetchErr}</p>
+      )}
+      {!fetchErr && sources.length > 0 && srcColumns.length === 0 && (
+        <p className="tabcontent__hint colcard-fetch-hint">
+          No source columns detected yet — click <strong>Fetch columns</strong> to read the headers.
+        </p>
+      )}
+
+      {columns.length > 0 ? (
+        <div className="colcard-list">
+          {columns.map((col, i) => (
+            <ColumnCard
+              //  Keyed on the column identity, not the index: ColumnCard holds local UI state and
+              //  an index key would carry that state to a different row when columns are reordered.
+              key={`${col.src_col_name ?? ''}->${col.dest_col_name ?? ''}`}
+              col={col}
+              index={i}
+              count={columns.length}
+              isExpanded={expandedIdx === i}
+              onToggle={() => toggleExpand(i)}
+              onUpdate={(next) => apply((it) => listUpdate(it, 'columns', i, next))}
+              onRemove={() => removeCol(i)}
+              onMove={(d) => moveCol(i, d)}
+              formatterTypes={formatterTypes}
+              onUpdateFmts={(fmts) => updateFmts(i, col, fmts)}
+              srcColumns={srcColumns}
+              onFetch={fetchColumns}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="empty-state">
+          <div className="empty-state__icon">
+            <Columns size={28} />
+          </div>
+          <div className="empty-state__text">
+            <strong>No columns mapped yet</strong>
+            <span>Add your first column mapping to define how source data maps to the output.</span>
+          </div>
+        </div>
+      )}
+
+      <button className="btn btn--solid colcard-add-btn" onClick={addColumn}>
+        <Plus size={14} /> Add column
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/editor/tabs/OutputTab.jsx
+++ b/frontend/src/components/editor/tabs/OutputTab.jsx
@@ -1,0 +1,35 @@
+//  Output editor — pick a writer type and configure its props via a schema-driven form. Covers the
+//  supported writers (delimited_file, excel, json_writer, splitted_file). Edits flow to the live YAML.
+
+import { useConfig } from '../../../state/ConfigContext.jsx';
+import SchemaForm from '../../../forms/SchemaForm.jsx';
+import { setField } from '../../../models/interfaceOps.js';
+import { OUTPUT_SCHEMAS, OUTPUT_TYPE_OPTIONS, outputSchema } from '../../../forms/schemas/outputSchemas.js';
+
+export default function OutputTab({ interfaceName, iface }) {
+  const { updateInterface } = useConfig();
+  const output = iface.output ?? {};
+  const props = output.props && !Array.isArray(output.props) ? output.props : {};
+
+  const apply = (fn) => updateInterface(interfaceName, fn);
+  // Reset props on type change so fields from the previous writer don't leak into the new one's YAML.
+  const setType = (type) => apply((it) => setField(it, 'output', type ? { type, props: {} } : {}));
+  const setProps = (next) => apply((it) => setField(it, 'output', { type: output.type, props: next }));
+
+  return (
+    <div className="tabcontent">
+      <p className="tabcontent__hint">How the formatted frame is persisted.</p>
+
+      <select className="field__input field__input--wide" value={output.type ?? ''} onChange={(e) => setType(e.target.value)}>
+        <option value="">— select writer —</option>
+        {OUTPUT_TYPE_OPTIONS.map((t) => <option key={t} value={t}>{OUTPUT_SCHEMAS[t].label}</option>)}
+      </select>
+
+      {output.type && (
+        <div className="outputform">
+          <SchemaForm schema={outputSchema(output.type)} value={props} onChange={setProps} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/editor/tabs/PostProcessingTab.jsx
+++ b/frontend/src/components/editor/tabs/PostProcessingTab.jsx
@@ -1,0 +1,93 @@
+//  Post-processing tab — frame-level transforms applied after column formatting, before final
+//  validation. The backend (ingen/post_processor) currently implements one processor: `pivot`,
+//  shaped { type: 'pivot', processing_values: { pivot_col, value_col } }. This is a form surface,
+//  not a graph.
+
+import { useConfig } from '../../../state/ConfigContext.jsx';
+import ListControls from '../../common/ListControls.jsx';
+import { listAdd, listUpdate, listRemove, listMove } from '../../../models/interfaceOps.js';
+
+
+function newStep() {
+  return { type: 'pivot', processing_values: { pivot_col: '', value_col: '' } };
+}
+
+export default function PostProcessingTab({ interfaceName, iface }) {
+  const { updateInterface } = useConfig();
+  const steps = iface.post_processing ?? [];
+
+  const apply = (fn) => updateInterface(interfaceName, fn);
+
+  const setPivotField = (i, step, key, value) => {
+    const processing_values = { ...(step.processing_values ?? {}), [key]: value || undefined };
+    apply((it) => listUpdate(it, 'post_processing', i, { ...step, processing_values }));
+  };
+
+  return (
+    <div className="tabcontent">
+      <p className="tabcontent__hint">
+        Applied after column formatting, before final validation. Pivot reshapes long rows into wide
+        columns: every value in <span className="mono">pivot column</span> becomes a new column filled
+        from <span className="mono">value column</span>.
+      </p>
+
+      <ol className="stepper">
+        {steps.map((step, i) => (
+          <li key={`${step.type}:${i}`} className="stepper__item stepper__item--editable">
+            <span className="stepper__num">{i + 1}</span>
+            <div className="stepper__body">
+              <div className="stepper__row">
+                <span className="chip chip--accent">{step.type}</span>
+                <ListControls
+                  index={i}
+                  count={steps.length}
+                  onMove={(d) => apply((it) => listMove(it, 'post_processing', i, d))}
+                  onRemove={() => apply((it) => listRemove(it, 'post_processing', i))}
+                />
+              </div>
+              {step.type === 'pivot' ? (
+                <div className="schemaform">
+                  <label className="field">
+                    <span className="field__label">Pivot column</span>
+                    <input
+                      className="field__input"
+                      placeholder="e.g. attribute"
+                      value={step.processing_values?.pivot_col ?? ''}
+                      onChange={(e) => setPivotField(i, step, 'pivot_col', e.target.value)}
+                    />
+                    <span className="field__help">Column whose distinct values become new columns.</span>
+                  </label>
+                  <label className="field">
+                    <span className="field__label">Value column</span>
+                    <input
+                      className="field__input"
+                      placeholder="e.g. amount"
+                      value={step.processing_values?.value_col ?? ''}
+                      onChange={(e) => setPivotField(i, step, 'value_col', e.target.value)}
+                    />
+                    <span className="field__help">Column whose values fill the new pivoted columns.</span>
+                  </label>
+                </div>
+              ) : (
+                <pre className="mono kvlist__json">{JSON.stringify(step.processing_values ?? {}, null, 2)}</pre>
+              )}
+            </div>
+          </li>
+        ))}
+        {steps.length === 0 && <li className="stepper__empty">No post-processing configured.</li>}
+      </ol>
+
+      <div className="addbar" style={{ marginTop: 10 }}>
+        <button
+          className="btn btn--solid"
+          onClick={() => apply((it) => listAdd(it, 'post_processing', newStep()))}
+        >
+          + Add pivot
+        </button>
+        <span className="muted" style={{ alignSelf: 'center' }}>
+          Pivot is the only post-processor the backend supports today.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/editor/tabs/SourcesTab.jsx
+++ b/frontend/src/components/editor/tabs/SourcesTab.jsx
@@ -1,0 +1,266 @@
+//  Sources tab — manages which config sources this interface consumes, and their order (source[0] is
+//  the pre-process base input). Now supports INLINE source creation: users can create a new source
+//  definition AND add it to the interface in a single action — no need to navigate to the separate
+//  Sources registry page first.
+
+import { useState } from 'react';
+import { Plus, Database, FileText, Globe, Braces, Trash2 } from 'lucide-react';
+import { useConfig } from '../../../state/ConfigContext.jsx';
+import { useSourceActions } from '../../../hooks/useSourceActions.js';
+import { upsertSource, removeSource } from '../../../models/configModel.js';
+import { SOURCE_TYPES } from '../../../models/constants.js';
+import ListControls from '../../common/ListControls.jsx';
+import { listAdd, listRemove, listMove } from '../../../models/interfaceOps.js';
+import ConfirmDialog from '../../common/ConfirmDialog.jsx';
+import SourceActionDialog from '../../common/SourceActionDialog.jsx';
+
+const TYPE_OPTIONS = Object.values(SOURCE_TYPES);
+
+const TYPE_META = {
+  file:         { icon: FileText,  color: '#3b82f6', label: 'File',          desc: 'CSV, Excel, XML, JSON, or fixed-width file' },
+  mysql:        { icon: Database,  color: '#f59e0b', label: 'MySQL',         desc: 'SQL query against a database' },
+  api:          { icon: Globe,     color: '#8b5cf6', label: 'API',           desc: 'HTTP endpoint (REST / SOAP)' },
+  json:         { icon: Braces,    color: '#10b981', label: 'JSON',          desc: 'Runtime JSON payload' },
+};
+
+function summarize(src) {
+  if (!src) return '—';
+  switch (src.type) {
+    case 'file': return src.file_path || src.file_type || 'file';
+    case 'mysql': return src.database || src.db_token || 'database';
+    case 'api': return src.url || 'HTTP endpoint';
+    case 'json': return 'runtime payload';
+    default: return '';
+  }
+}
+
+export default function SourcesTab({ interfaceName, iface }) {
+  const { model, updateModel, updateInterface } = useConfig();
+  const ids = iface.sources ?? [];
+  const available = model.sourceOrder.filter((id) => !ids.includes(id));
+
+  // Existing source picker
+  const [pick, setPick] = useState('');
+
+  // Inline creation form
+  const [showCreate, setShowCreate] = useState(false);
+  const [newId, setNewId] = useState('');
+  const [newType, setNewType] = useState('file');
+
+  // Delete from registry
+  const [confirmDelSrc, setConfirmDelSrc] = useState(null); // sourceId | null
+
+  // Source action dialog (new interface vs merge)
+  const { pendingSourceAction, setPendingSourceAction, handleNewInterface, handleMergeSource } =
+    useSourceActions(interfaceName);
+
+  const idTaken = Boolean(model.sourcesById[newId.trim()]);
+  const canCreate = newId.trim().length > 0 && !idTaken;
+
+  const apply = (fn) => updateInterface(interfaceName, fn);
+
+  // Delete source from global registry AND remove it from ALL interfaces that reference it.
+  const deleteFromRegistry = (srcId) => {
+    updateModel((m) => {
+      let next = removeSource(m, srcId);
+      // Strip from every interface's sources array.
+      for (const [name, it] of Object.entries(next.interfacesByName)) {
+        const filtered = (it.sources ?? []).filter((s) => s !== srcId);
+        if (filtered.length !== (it.sources ?? []).length) {
+          next = { ...next, interfacesByName: { ...next.interfacesByName, [name]: { ...it, sources: filtered } } };
+        }
+      }
+      return next;
+    });
+    setConfirmDelSrc(null);
+  };
+
+  // Create a new source in the registry AND add it to this interface
+  const createAndAdd = () => {
+    const id = newId.trim();
+    if (!id || model.sourcesById[id]) return;
+    // 1. Create in registry
+    updateModel((m) => upsertSource(m, { id, type: newType }));
+    // 2. If interface already has sources, show choice dialog
+    if (ids.length > 0) {
+      setPendingSourceAction({ sid: id });
+      setNewId('');
+      setShowCreate(false);
+      return;
+    }
+    // 3. Otherwise add directly
+    apply((it) => listAdd(it, 'sources', id));
+    setNewId('');
+    setShowCreate(false);
+  };
+
+  // Add existing source
+  const addExisting = () => {
+    if (!pick) return;
+    if (ids.length > 0) {
+      setPendingSourceAction({ sid: pick });
+      setPick('');
+      return;
+    }
+    apply((it) => listAdd(it, 'sources', pick));
+    setPick('');
+  };
+
+  // Source action dialog handlers
+
+
+  return (
+    <div className="tabcontent">
+      <p className="tabcontent__hint">
+        Ordered source inputs — row 1 is the pipeline base input. Use the trash icon to permanently
+        delete a source from the registry (removes it from all interfaces).
+      </p>
+
+      {/* ── Source cards ── */}
+      {ids.length > 0 ? (
+        <div className="src-cards">
+          {ids.map((id, i) => {
+            const src = model.sourcesById[id];
+            const meta = TYPE_META[src?.type] || TYPE_META.file;
+            const Icon = meta.icon;
+            return (
+              <div key={id} className="src-card">
+                <div className="src-card__left">
+                  <span className="src-card__rank">{i + 1}</span>
+                  <div className="src-card__icon" style={{ backgroundColor: `${meta.color}12`, color: meta.color }}>
+                    <Icon size={16} />
+                  </div>
+                  <div className="src-card__info">
+                    <span className="src-card__id">{id}</span>
+                    <span className="src-card__detail">
+                      <span className="src-card__type-chip" style={{ color: meta.color, background: `${meta.color}10`, borderColor: `${meta.color}30` }}>{meta.label}</span>
+                      {summarize(src) && <span className="src-card__summary">{summarize(src)}</span>}
+                    </span>
+                  </div>
+                </div>
+                <div className="src-card__controls">
+                  <ListControls
+                    index={i}
+                    count={ids.length}
+                    onMove={(d) => apply((it) => listMove(it, 'sources', i, d))}
+                    onRemove={() => apply((it) => listRemove(it, 'sources', i))}
+                  />
+                  <button
+                    className="src-card__del-btn"
+                    title="Delete from registry (removes from all interfaces)"
+                    onClick={() => setConfirmDelSrc(id)}
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="empty-state">
+          <div className="empty-state__icon">
+            <Database size={28} />
+          </div>
+          <div className="empty-state__text">
+            <strong>No sources on this interface</strong>
+            <span>Create a new source or add an existing one to get started.</span>
+          </div>
+        </div>
+      )}
+
+      {/* ── Add actions ── */}
+      <div className="src-actions">
+        {/* Add existing source */}
+        {available.length > 0 && (
+          <div className="src-actions__existing">
+            <select className="field__input" value={pick} onChange={(e) => setPick(e.target.value)}>
+              <option value="">— select an existing source —</option>
+              {available.map((id) => {
+                const src = model.sourcesById[id];
+                const meta = TYPE_META[src?.type] || TYPE_META.file;
+                return <option key={id} value={id}>{id} ({meta.label})</option>;
+              })}
+            </select>
+            <button className="btn btn--ghost" disabled={!pick} onClick={addExisting}>
+              <Plus size={14} /> Add
+            </button>
+          </div>
+        )}
+
+        {/* Create new source */}
+        {!showCreate ? (
+          <button className="btn btn--solid src-actions__create-btn" onClick={() => setShowCreate(true)}>
+            <Plus size={14} /> Create new source
+          </button>
+        ) : (
+          <div className="src-create-form">
+            <div className="src-create-form__header">
+              <span className="src-create-form__title">Create new source</span>
+              <button className="navrail__icon-btn" onClick={() => { setShowCreate(false); setNewId(''); }}>
+                ✕
+              </button>
+            </div>
+            <div className="src-create-form__body">
+              <div className="src-create-form__row">
+                <div className="field">
+                  <label className="field__label">Source ID</label>
+                  <input
+                    className={`field__input${idTaken ? ' field__input--err' : ''}`}
+                    placeholder="e.g. my_data_file"
+                    value={newId}
+                    autoFocus
+                    onChange={(e) => setNewId(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && canCreate) createAndAdd();
+                      if (e.key === 'Escape') { setShowCreate(false); setNewId(''); }
+                    }}
+                  />
+                  {idTaken && <span className="field__help field__help--err">A source with this ID already exists</span>}
+                </div>
+                <div className="field">
+                  <label className="field__label">Type</label>
+                  <select className="field__input" value={newType} onChange={(e) => setNewType(e.target.value)}>
+                    {TYPE_OPTIONS.map((t) => {
+                      const m = TYPE_META[t] || {};
+                      return <option key={t} value={t}>{m.label || t}</option>;
+                    })}
+                  </select>
+                </div>
+              </div>
+              {/* Type description */}
+              <p className="src-create-form__type-desc">
+                {TYPE_META[newType]?.desc || ''}
+              </p>
+              <button
+                className="btn btn--solid"
+                disabled={!canCreate}
+                onClick={createAndAdd}
+              >
+                <Plus size={14} /> Create & add to interface
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={Boolean(confirmDelSrc)}
+        title="Delete source"
+        message={`Delete source "${confirmDelSrc}" from the registry? It will be removed from every interface that references it. This can't be undone.`}
+        confirmLabel="Delete source"
+        danger
+        onConfirm={() => deleteFromRegistry(confirmDelSrc)}
+        onCancel={() => setConfirmDelSrc(null)}
+      />
+
+      <SourceActionDialog
+        open={Boolean(pendingSourceAction)}
+        sourceId={pendingSourceAction?.sid ?? ''}
+        onNewInterface={handleNewInterface}
+        onMerge={handleMergeSource}
+        onCancel={() => setPendingSourceAction(null)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/editor/tabs/ValidationsTab.jsx
+++ b/frontend/src/components/editor/tabs/ValidationsTab.jsx
@@ -1,0 +1,96 @@
+//  Validations editor — great_expectations checks on the formatted frame, stored PER COLUMN under
+//  columns[i].validations[] (matches ingen/validation/validations.py). Add/edit/remove with
+//  expectation type, severity (→ action), and expectation args.
+
+import { useState } from 'react';
+import { useConfig } from '../../../state/ConfigContext.jsx';
+import { useGraphSelection } from '../../../state/GraphSelectionContext.jsx';
+import { colValAdd, colValUpdate, colValRemove } from '../../../models/interfaceOps.js';
+import {
+  ALL_EXPECTATIONS, SEVERITY_OPTIONS, SEVERITY_ACTION, VALIDATION_ARG_HINTS,
+} from '../../../forms/schemas/validationSchemas.js';
+import { JsonField } from '../../../forms/fields/Fields.jsx';
+
+const colLabel = (c) => c.dest_col_name || c.src_col_name || '(unnamed)';
+
+export default function ValidationsTab({ interfaceName, iface }) {
+  const { updateInterface } = useConfig();
+  const { setSelectedNodeId } = useGraphSelection();
+  const columns = iface.columns ?? [];
+  const [target, setTarget] = useState(0);
+  const [expectation, setExpectation] = useState(ALL_EXPECTATIONS[0]);
+
+  //  `target` is a column INDEX, so deleting a column can leave it pointing past the end (or at a
+  //  different column than the user picked). Clamp on read rather than storing a corrected value,
+  //  so the selection repairs itself without an extra render.
+  const safeTarget = target < columns.length ? target : 0;
+
+  const apply = (fn) => updateInterface(interfaceName, fn);
+
+  // Flatten validations across columns into addressable rows.
+  const rows = columns.flatMap((col, ci) =>
+    (col.validations ?? []).map((v, vi) => ({ ci, vi, col, v })));
+
+  return (
+    <div className="tabcontent">
+      <p className="tabcontent__hint">
+        Expectations run on the formatted output. Severity decides the action:
+        <span className="chip chip--warn">blocker</span> aborts ·
+        <span className="chip chip--warn">critical</span> drops rows ·
+        <span className="chip">warning</span> reports.
+      </p>
+
+      {columns.length === 0 ? (
+        <div className="emptyblock">
+          Add columns first — validations attach to a column.
+          <button className="btn btn--ghost btn--xs" style={{ marginLeft: 8 }} onClick={() => setSelectedNodeId('columns-node')}>
+            Go to Columns →
+          </button>
+        </div>
+      ) : (
+        <div className="addbar">
+          <select className="field__input" value={safeTarget} onChange={(e) => setTarget(Number(e.target.value))}>
+            {columns.map((c, i) => <option key={`${colLabel(c)}:${i}`} value={i}>{colLabel(c)}</option>)}
+          </select>
+          <select className="field__input field__input--wide" value={expectation} onChange={(e) => setExpectation(e.target.value)}>
+            {ALL_EXPECTATIONS.map((t) => <option key={t} value={t}>{t}</option>)}
+          </select>
+          <button
+            className="btn btn--solid"
+            onClick={() => apply((it) => colValAdd(it, safeTarget, { type: expectation, severity: 'warning' }))}
+          >
+            + Add
+          </button>
+        </div>
+      )}
+
+      <div className="vlist">
+        {rows.map(({ ci, vi, col, v }) => (
+          <div key={`${ci}-${vi}`} className="vrow">
+            <div className="vrow__head">
+              <span className="chip">{colLabel(col)}</span>
+              <span className="mono vrow__type">{v.type}</span>
+              <select
+                className="field__input vrow__sev"
+                value={v.severity ?? 'warning'}
+                onChange={(e) => apply((it) => colValUpdate(it, ci, vi, { ...v, severity: e.target.value }))}
+              >
+                {SEVERITY_OPTIONS.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+              <span className="vrow__action muted">{SEVERITY_ACTION[v.severity ?? 'warning']}</span>
+              <button className="lctrls__btn lctrls__btn--del" title="Remove validation" aria-label="Remove validation" onClick={() => apply((it) => colValRemove(it, ci, vi))}>✕</button>
+            </div>
+            <JsonField
+              label="args"
+              help={VALIDATION_ARG_HINTS[v.type] || 'no args'}
+              value={v.args}
+              rows={1}
+              onChange={(args) => apply((it) => colValUpdate(it, ci, vi, { ...v, args }))}
+            />
+          </div>
+        ))}
+        {columns.length > 0 && rows.length === 0 && <div className="emptyblock">No validations configured.</div>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the interface editor — the part of InGen Studio where a config is actually authored. Three
ways to edit the same model: **structured tabs**, a **visual graph canvas (inFlow)**, and a
**conversational panel (inChat)**.

This is part 4 of the frontend series. **All new files under
`frontend/src/components/editor/`** — nothing existing is modified.

| Area | What it does |
|---|---|
| `editor/tabs/` | Sources, Columns, Output and Validations tabs — the structured editing surface. |
| `editor/graph/` | inFlow canvas: sources, pre-processing steps and output as a directed graph, with a sidebar node creator. |
| `editor/chat/` | inChat panel — describe a change in words, see it applied to the model. |

## Screenshots

Source loader — pick a source type, configure it:

![Source loader](https://raw.githubusercontent.com/maan-iitd2/ingen/pr-assets/screenshots/02-source-loader.png)

inFlow graph canvas — the pipeline as a directed graph:

![inFlow graph canvas](https://raw.githubusercontent.com/maan-iitd2/ingen/pr-assets/screenshots/03-inflow-graph-canvas-full.png)

Columns tab — mapping source columns to output columns, with per-column formatters:

![Columns editor](https://raw.githubusercontent.com/maan-iitd2/ingen/pr-assets/screenshots/08-columns-editor.png)

inChat panel — the same model edited conversationally; note the YAML panel on the right updating from the same edits:

![inChat panel](https://raw.githubusercontent.com/maan-iitd2/ingen/pr-assets/screenshots/04-inchat-panel.png)

> Images are hosted on a `pr-assets` branch of the fork, so they add **nothing** to this diff.

## ⚠️ Please read before reviewing

**This builds on #76 and the two preceding frontend PRs, and CI will fail here until they merge.**
These components import `@/models/*`, `@/serializers/*`, `@/services/*` and `@/state/*`. Expected —
not a defect in this branch.

The diff is **conflict-free and independent**: no file here is touched by any other open PR.

**On inChat scope:** the panel in this PR is UI only, and it works standalone in `mock` mode. The
backend endpoint it calls in `http` mode is a **deliberate follow-up PR**, held back so that the
backend wrapper (#75) can be reviewed on its own first. Nothing in this PR requires that endpoint to
exist — no new Python dependency is introduced here.

## Design notes for reviewers

- **All three surfaces edit one model.** Tabs, graph and chat are views over the same config object,
  not parallel implementations — edits made in any one immediately appear in the others and in the
  YAML panel. This is the single most important thing to sanity-check in review.
- **The graph is derived, never authoritative.** Node positions are layout only; the config model
  stays the source of truth, so a graph bug can't corrupt a config.
- If this PR feels too large to review in one pass, it splits cleanly along
  `editor/tabs/` vs `editor/graph/` — happy to break it in two on request.

## Testing

Verified on a local integration branch (`main` + #76 + the two preceding frontend PRs + this PR):

- `npm run build` — full `next build` compiles clean, all 6 routes generated
- `npm run test` — 57/57 pass
- `npm run dev` in mock mode — browser smoke pass: start screen → create pipeline → editor with
  source loader and live YAML panel → run console, **0 console errors**
- Re-verified alongside the Python side: `pytest test/` and `pytest backend/tests/` (42 passed), no
  new failures; a real `python -m ingen` CLI run and a real HTTP run through the backend both
  completed with all five stages `ok`

### Quality gates

All green on the integration branch:

| Gate | Result |
|---|---|
| `npm run lint` | 0 errors, 0 warnings |
| `npm run test` | 57 / 57 |
| `npm run build` | compiles, all 6 routes generated |
| `pytest test/` | no new failures vs. baseline |
| `pytest backend/tests/` | 42 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

